### PR TITLE
[DEBUG] Temporary fix for issue "'RoIAlignRotated' object has no attribute 'out_size'" #40

### DIFF
--- a/mmrotate/models/roi_heads/roi_extractors/rotate_single_level_roi_extractor.py
+++ b/mmrotate/models/roi_heads/roi_extractors/rotate_single_level_roi_extractor.py
@@ -98,19 +98,21 @@ class RotatedSingleRoIExtractor(BaseRoIExtractor):
         Returns:
             torch.Tensor: Scaled RoI features.
         """
-        out_size = self.roi_layers[0].out_size
+        if isinstance(self.roi_layers[0], ops.RiRoIAlignRotated):
+            out_size = nn.modules.utils._pair(self.roi_layers[0].out_size)
+        else:
+            out_size = self.roi_layers[0].output_size
         num_levels = len(feats)
-        expand_dims = (-1, self.out_channels * out_size * out_size)
+        expand_dims = (-1, self.out_channels * out_size[0] * out_size[1])
         if torch.onnx.is_in_onnx_export():
             # Work around to export mask-rcnn to onnx
             roi_feats = rois[:, :1].clone().detach()
             roi_feats = roi_feats.expand(*expand_dims)
-            roi_feats = roi_feats.reshape(-1, self.out_channels, out_size,
-                                          out_size)
+            roi_feats = roi_feats.reshape(-1, self.out_channels, *out_size)
             roi_feats = roi_feats * 0
         else:
             roi_feats = feats[0].new_zeros(
-                rois.size(0), self.out_channels, out_size, out_size)
+                rois.size(0), self.out_channels, *out_size)
         # TODO: remove this when parrots supports
         if torch.__version__ == 'parrots':
             roi_feats.requires_grad = True


### PR DESCRIPTION
## Motivation
Debug for issue #40 

## Modification
Since `RiRoIAlignRotated` object does not have attribute `output_size` but `out_size`, and vice versa for other RoI in `mmcv`.
-> Check if object is `RiRoIAlignRotated` then get `out_size` attribute, if not get `output_size` 

## BC-breaking (Optional)
This change make code work without changing downstream repo (`mmcv`), however I think better to update downstream `mmcv` repo; specifically in https://github.com/open-mmlab/mmcv/blob/fd3a1a16ea1d0b3def8719816007a5d6fd6b432e/mmcv/ops/riroi_align_rotated.py#L121
=> `self.out_size` to `self.output_size`

## Use cases (Optional)
If this PR is for debugging #40 
