### PR TITLE
[Fix] Bug for SASM durning training.

### DIFF
--- a/mmrotate/models/dense_heads/sam_reppoints_head.py
+++ b/mmrotate/models/dense_heads/sam_reppoints_head.py
@@ -328,8 +328,8 @@ class SAMRepPointsHead(BaseDenseHead):
             if self.train_cfg.refine.assigner.type not in (
                     'ATSSAssigner', 'ATSSConvexAssigner', 'SASAssigner'):
                 assign_result = assigner.assign(
-                    proposals, gt_bboxes, gt_bboxes_ignore,
-                    None if self.sampling else gt_labels, overlaps)
+                    proposals, gt_bboxes, overlaps, gt_bboxes_ignore,
+                    None if self.sampling else gt_labels)
             else:
                 assign_result = assigner.assign(
                     proposals, num_level_anchors_inside, gt_bboxes,

--- a/mmrotate/models/dense_heads/sam_reppoints_head.py
+++ b/mmrotate/models/dense_heads/sam_reppoints_head.py
@@ -320,16 +320,16 @@ class SAMRepPointsHead(BaseDenseHead):
             assigner = self.init_assigner
             pos_weight = self.train_cfg.init.pos_weight
             assign_result = assigner.assign(
-                proposals, gt_bboxes, overlaps, gt_bboxes_ignore,
-                None if self.sampling else gt_labels)
+                proposals, gt_bboxes, gt_bboxes_ignore,
+                None if self.sampling else gt_labels, overlaps)
         else:
             assigner = self.refine_assigner
             pos_weight = self.train_cfg.refine.pos_weight
             if self.train_cfg.refine.assigner.type not in (
                     'ATSSAssigner', 'ATSSConvexAssigner', 'SASAssigner'):
                 assign_result = assigner.assign(
-                    proposals, gt_bboxes, overlaps, gt_bboxes_ignore,
-                    None if self.sampling else gt_labels)
+                    proposals, gt_bboxes, gt_bboxes_ignore,
+                    None if self.sampling else gt_labels, overlaps)
             else:
                 assign_result = assigner.assign(
                     proposals, num_level_anchors_inside, gt_bboxes,
@@ -491,7 +491,8 @@ class SAMRepPointsHead(BaseDenseHead):
             gt_bboxes_ignore_list = [None for _ in range(num_imgs)]
         if gt_labels_list is None:
             gt_labels_list = [None for _ in range(num_imgs)]
-        all_overlaps_rotate_list = [None] * 4
+        len_gt_labels = len(gt_bboxes_list)
+        all_overlaps_rotate_list = [None] * len_gt_labels
         (all_labels, all_label_weights, all_bbox_gt, all_proposals,
          all_proposal_weights, pos_inds_list, neg_inds_list, all_gt_inds_list,
          all_sam_init_weights) = multi_apply(


### PR DESCRIPTION
1.assign函数参数顺序错误，overlaps参数位置错误（这个问题不影响正常训练，是我调试的时候发现的，你们可以确认一下，这个有没响）
2.all_overlaps_rotate_list之前大小固定为4，应该按照一个batchsize大小进行设置，修改之后不会报tensor维度错误，可以正常训练
（修改了lint错误，重新提交一次）
