### PR TITLE
[Enhance] Refactor `imshow_det_rbboxes`

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -6,8 +6,7 @@ We provide a demo script to test a single image.
 python demo/image_demo.py \
     ${IMG_ROOT} \
     ${CONFIG_FILE} \
-    ${CHECKPOINT_FILE} \
-    ${OUTPUT_ROOT}]
+    ${CHECKPOINT_FILE}
 ```
 
 Examples:
@@ -16,6 +15,5 @@ Examples:
     python demo/image_demo.py \
         demo/demo.jpg \
         work_dirs/oriented_rcnn_r50_fpn_1x_dota_v3/oriented_rcnn_r50_fpn_1x_dota_v3.py \
-        work_dirs/oriented_rcnn_r50_fpn_1x_dota_v3/epoch_12.pth \
-        demo/vis.jpg
+        work_dirs/oriented_rcnn_r50_fpn_1x_dota_v3/epoch_12.pth
 ```

--- a/demo/huge_image_demo.py
+++ b/demo/huge_image_demo.py
@@ -49,6 +49,11 @@ def parse_args():
     parser.add_argument(
         '--device', default='cuda:0', help='Device used for inference')
     parser.add_argument(
+        '--palette',
+        default='dota',
+        choices=['dota', 'random'],
+        help='Color palette used for visualization')
+    parser.add_argument(
         '--score-thr', type=float, default=0.3, help='bbox score threshold')
     args = parser.parse_args()
     return args
@@ -62,7 +67,12 @@ def main(args):
                                            args.patch_steps, args.img_ratios,
                                            args.merge_iou_thr)
     # show the results
-    show_result_pyplot(model, args.img, result, score_thr=args.score_thr)
+    show_result_pyplot(
+        model,
+        args.img,
+        result,
+        palette=args.palette,
+        score_thr=args.score_thr)
 
 
 if __name__ == '__main__':

--- a/demo/huge_image_demo.py
+++ b/demo/huge_image_demo.py
@@ -51,7 +51,7 @@ def parse_args():
     parser.add_argument(
         '--palette',
         default='dota',
-        choices=['dota', 'random'],
+        choices=['dota', 'sar', 'hrsc', 'hrsc_classwise', 'random'],
         help='Color palette used for visualization')
     parser.add_argument(
         '--score-thr', type=float, default=0.3, help='bbox score threshold')

--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -30,7 +30,7 @@ def parse_args():
     parser.add_argument(
         '--palette',
         default='dota',
-        choices=['dota', 'random'],
+        choices=['dota', 'sar', 'hrsc', 'hrsc_classwise', 'random'],
         help='Color palette used for visualization')
     parser.add_argument(
         '--score-thr', type=float, default=0.3, help='bbox score threshold')

--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -9,39 +9,49 @@ wget -P checkpoint https://download.openmmlab.com/mmrotate/v0.1.0/oriented_rcnn/
 python demo/image_demo.py \
     demo/demo.jpg \
     configs/oriented_rcnn/oriented_rcnn_r50_fpn_1x_dota_le90.py \
-    checkpoint/oriented_rcnn_r50_fpn_1x_dota_le90-6d2b2ce0.pth \
-    demo/vis.jpg
+    work_dirs/oriented_rcnn_r50_fpn_1x_dota_v3/epoch_12.pth
 ```
 """  # nowq
 
 from argparse import ArgumentParser
 
-from mmdet.apis import inference_detector, init_detector
+from mmdet.apis import inference_detector, init_detector, show_result_pyplot
 
 import mmrotate  # noqa: F401
 
 
-def main():
-    """Test a single image."""
+def parse_args():
     parser = ArgumentParser()
     parser.add_argument('img', help='Image file')
     parser.add_argument('config', help='Config file')
     parser.add_argument('checkpoint', help='Checkpoint file')
-    parser.add_argument('output', help='Output image')
     parser.add_argument(
         '--device', default='cuda:0', help='Device used for inference')
     parser.add_argument(
+        '--palette',
+        default='dota',
+        choices=['dota', 'random'],
+        help='Color palette used for visualization')
+    parser.add_argument(
         '--score-thr', type=float, default=0.3, help='bbox score threshold')
     args = parser.parse_args()
+    return args
 
+
+def main(args):
     # build the model from a config file and a checkpoint file
     model = init_detector(args.config, args.checkpoint, device=args.device)
     # test a single image
     result = inference_detector(model, args.img)
     # show the results
-    model.show_result(
-        args.img, result, score_thr=args.score_thr, out_file=args.output)
+    show_result_pyplot(
+        model,
+        args.img,
+        result,
+        palette=args.palette,
+        score_thr=args.score_thr)
 
 
 if __name__ == '__main__':
-    main()
+    args = parse_args()
+    main(args)

--- a/docs/en/api.rst
+++ b/docs/en/api.rst
@@ -31,6 +31,11 @@ post_processing
 .. automodule:: mmrotate.core.post_processing
     :members:
 
+visualization
+^^^^^^^^^^^^^
+.. automodule:: mmrotate.core.visualization
+    :members:
+
 mmrotate.datasets
 --------------
 

--- a/docs/zh_cn/api.rst
+++ b/docs/zh_cn/api.rst
@@ -31,6 +31,11 @@ post_processing
 .. automodule:: mmrotate.core.post_processing
     :members:
 
+visualization
+^^^^^^^^^^^^^
+.. automodule:: mmrotate.core.visualization
+    :members:
+
 mmrotate.datasets
 --------------
 

--- a/mmrotate/core/visualization/__init__.py
+++ b/mmrotate/core/visualization/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .image import imshow_det_rbboxes
+from .palette import get_palette
 
-__all__ = ['imshow_det_rbboxes']
+__all__ = ['imshow_det_rbboxes', 'get_palette']

--- a/mmrotate/core/visualization/image.py
+++ b/mmrotate/core/visualization/image.py
@@ -1,107 +1,244 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import math
 
 import cv2
+import matplotlib.pyplot as plt
+import mmcv
 import numpy as np
-from mmcv.image import imread, imwrite
-from mmcv.visualization.color import color_val
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Polygon
+from mmdet.core.visualization import palette_val
+from mmdet.core.visualization.image import draw_labels, draw_masks
+
+from mmrotate.core.visualization.palette import get_palette
+
+EPS = 1e-2
 
 
-def imshow(img, win_name='', wait_time=0):
-    """Show an image.
+def _get_adaptive_scales(areas, min_area=800, max_area=30000):
+    """Get adaptive scales according to areas.
+
+    The scale range is [0.5, 1.0]. When the area is less than
+    ``'min_area'``, the scale is 0.5 while the area is larger than
+    ``'max_area'``, the scale is 1.0.
 
     Args:
-        img (str or ndarray): The image to be displayed.
-        win_name (str): The window name.
-        wait_time (int): Value of waitKey param.
-    """
-    cv2.imshow(win_name, imread(img))
-    if wait_time == 0:  # prevent from hanging if windows was closed
-        while True:
-            ret = cv2.waitKey(1)
+        areas (ndarray): The areas of bboxes or masks with the
+            shape of (n, ).
+        min_area (int): Lower bound areas for adaptive scales.
+            Default: 800.
+        max_area (int): Upper bound areas for adaptive scales.
+            Default: 30000.
 
-            closed = cv2.getWindowProperty(win_name, cv2.WND_PROP_VISIBLE) < 1
-            # if user closed window or if some key pressed
-            if closed or ret != -1:
-                break
-    else:
-        ret = cv2.waitKey(wait_time)
+    Returns:
+        ndarray: The adaotive scales with the shape of (n, ).
+    """
+    scales = 0.5 + (areas - min_area) / (max_area - min_area)
+    scales = np.clip(scales, 0.5, 1.0)
+    return scales
+
+
+def draw_bboxes(ax, bboxes, color='g', alpha=0.8, thickness=2):
+    """Draw bounding boxes on the axes.
+
+    Args:
+        ax (matplotlib.Axes): The input axes.
+        bboxes (ndarray): The input bounding boxes with the shape
+            of (n, 5).
+        color (list[tuple] | matplotlib.color): the colors for each
+            bounding boxes.
+        alpha (float): Transparency of bounding boxes. Default: 0.8.
+        thickness (int): Thickness of lines. Default: 2.
+
+    Returns:
+        matplotlib.Axes: The result axes.
+    """
+    polygons = []
+    for i, bbox in enumerate(bboxes):
+        xc, yc, w, h, ag = bbox[:5]
+        wx, wy = w / 2 * np.cos(ag), w / 2 * np.sin(ag)
+        hx, hy = -h / 2 * np.sin(ag), h / 2 * np.cos(ag)
+        p1 = (xc - wx - hx, yc - wy - hy)
+        p2 = (xc + wx - hx, yc + wy - hy)
+        p3 = (xc + wx + hx, yc + wy + hy)
+        p4 = (xc - wx + hx, yc - wy + hy)
+        poly = np.int0(np.array([p1, p2, p3, p4]))
+        polygons.append(Polygon(poly))
+    p = PatchCollection(
+        polygons,
+        facecolor='none',
+        edgecolors=color,
+        linewidths=thickness,
+        alpha=alpha)
+    ax.add_collection(p)
+
+    return ax
 
 
 def imshow_det_rbboxes(img,
-                       bboxes,
-                       labels,
+                       bboxes=None,
+                       labels=None,
+                       segms=None,
                        class_names=None,
-                       score_thr=0.3,
-                       bbox_color=(226, 43, 138),
-                       text_color='white',
+                       score_thr=0,
+                       bbox_color='green',
+                       text_color='green',
+                       mask_color=None,
                        thickness=2,
-                       font_scale=0.25,
-                       show=True,
+                       font_size=13,
                        win_name='',
+                       show=True,
                        wait_time=0,
                        out_file=None):
     """Draw bboxes and class labels (with scores) on an image.
 
     Args:
-        img (str or ndarray): The image to be displayed.
+        img (str | ndarray): The image to be displayed.
         bboxes (ndarray): Bounding boxes (with scores), shaped (n, 5) or
             (n, 6).
         labels (ndarray): Labels of bboxes.
+        segms (ndarray | None): Masks, shaped (n,h,w) or None.
         class_names (list[str]): Names of each classes.
-        score_thr (float): Minimum score of bboxes to be shown.
-        bbox_color (str or tuple or :obj:`Color`): Color of bbox lines.
-        text_color (str or tuple or :obj:`Color`): Color of texts.
-        thickness (int): Thickness of lines.
-        font_scale (float): Font scales of texts.
-        show (bool): Whether to show the image.
-        win_name (str): The window name.
-        wait_time (int): Value of waitKey param.
-        out_file (str or None): The filename to write the image.
-    """
-    assert bboxes is not None and bboxes.ndim == 2
-    assert labels.ndim == 1
+        score_thr (float): Minimum score of bboxes to be shown. Default: 0.
+        bbox_color (list[tuple] | tuple | str | None): Colors of bbox lines.
+           If a single color is given, it will be applied to all classes.
+           The tuple of color should be in RGB order. Default: 'green'.
+        text_color (list[tuple] | tuple | str | None): Colors of texts.
+           If a single color is given, it will be applied to all classes.
+           The tuple of color should be in RGB order. Default: 'green'.
+        mask_color (list[tuple] | tuple | str | None, optional): Colors of
+           masks. If a single color is given, it will be applied to all
+           classes. The tuple of color should be in RGB order.
+           Default: None.
+        thickness (int): Thickness of lines. Default: 2.
+        font_size (int): Font size of texts. Default: 13.
+        show (bool): Whether to show the image. Default: True.
+        win_name (str): The window name. Default: ''.
+        wait_time (float): Value of waitKey param. Default: 0.
+        out_file (str, optional): The filename to write the image.
+            Default: None.
 
-    img = imread(img)
+    Returns:
+        ndarray: The image with bboxes drawn on it.
+    """
+    assert bboxes is None or bboxes.ndim == 2, \
+        f' bboxes ndim should be 2, but its ndim is {bboxes.ndim}.'
+    assert labels.ndim == 1, \
+        f' labels ndim should be 1, but its ndim is {labels.ndim}.'
+    assert bboxes is None or bboxes.shape[1] == 5 or bboxes.shape[1] == 6, \
+        f' bboxes.shape[1] should be 4 or 5, but its {bboxes.shape[1]}.'
+    assert bboxes is None or bboxes.shape[0] <= labels.shape[0], \
+        'labels.shape[0] should not be less than bboxes.shape[0].'
+    assert segms is None or segms.shape[0] == labels.shape[0], \
+        'segms.shape[0] and labels.shape[0] should have the same length.'
+    assert segms is not None or bboxes is not None, \
+        'segms and bboxes should not be None at the same time.'
+
+    img = mmcv.imread(img).astype(np.uint8)
 
     if score_thr > 0:
-        assert bboxes.shape[1] == 6
+        assert bboxes is not None and bboxes.shape[1] == 6
         scores = bboxes[:, -1]
         inds = scores > score_thr
         bboxes = bboxes[inds, :]
         labels = labels[inds]
+        if segms is not None:
+            segms = segms[inds, ...]
 
-    bbox_color = (226, 43,
-                  138) if bbox_color is None else color_val(bbox_color)
-    text_color = (255, 255,
-                  255) if text_color is None else color_val(text_color)
-    for bbox, label in zip(bboxes, labels):
-        xc, yc, w, h, ag = bbox[:5]
-        score = bbox[5] if bboxes.shape[1] == 6 else None
-        wx, wy = w / 2 * math.cos(ag), w / 2 * math.sin(ag)
-        hx, hy = -h / 2 * math.sin(ag), h / 2 * math.cos(ag)
-        p1 = (xc - wx - hx, yc - wy - hy)
-        p2 = (xc + wx - hx, yc + wy - hy)
-        p3 = (xc + wx + hx, yc + wy + hy)
-        p4 = (xc - wx + hx, yc - wy + hy)
-        ps = np.int0(np.array([p1, p2, p3, p4]))
-        cv2.drawContours(img, [ps], -1, bbox_color, thickness=thickness)
-        label_text = class_names[
-            label] if class_names is not None else 'cls {}'.format(label)
-        if score:
-            label_text += '|{:.02f}'.format(score)
-        font = cv2.FONT_HERSHEY_COMPLEX
-        text_size = cv2.getTextSize(label_text, font, font_scale, 1)
-        text_width = text_size[0][0]
-        text_height = text_size[0][1]
-        cv2.rectangle(img, (int(xc), int(yc) - text_height - 2),
-                      (int(xc) + text_width, int(yc) + 3), (0, 128, 0), -1)
-        cv2.putText(img, label_text, (int(xc), int(yc)), font, font_scale,
-                    text_color, 1)
+    img = mmcv.bgr2rgb(img)
+    width, height = img.shape[1], img.shape[0]
+    img = np.ascontiguousarray(img)
+
+    fig = plt.figure(win_name, frameon=False)
+    plt.title(win_name)
+    canvas = fig.canvas
+    dpi = fig.get_dpi()
+    # add a small EPS to avoid precision lost due to matplotlib's truncation
+    # (https://github.com/matplotlib/matplotlib/issues/15363)
+    fig.set_size_inches((width + EPS) / dpi, (height + EPS) / dpi)
+
+    # remove white edges by set subplot margin
+    plt.subplots_adjust(left=0, right=1, bottom=0, top=1)
+    ax = plt.gca()
+    ax.axis('off')
+
+    max_label = int(max(labels) if len(labels) > 0 else 0)
+    text_palette = palette_val(get_palette(text_color, max_label + 1))
+    text_colors = [text_palette[label] for label in labels]
+
+    num_bboxes = 0
+    if bboxes is not None:
+        num_bboxes = bboxes.shape[0]
+        bbox_palette = palette_val(get_palette(bbox_color, max_label + 1))
+        colors = [bbox_palette[label] for label in labels[:num_bboxes]]
+        draw_bboxes(ax, bboxes, colors, alpha=0.8, thickness=thickness)
+
+        horizontal_alignment = 'left'
+        positions = bboxes[:, :2].astype(np.int32) + thickness
+        areas = bboxes[:, 2] * bboxes[:, 3]
+        scales = _get_adaptive_scales(areas)
+        scores = bboxes[:, 5] if bboxes.shape[1] == 6 else None
+        draw_labels(
+            ax,
+            labels[:num_bboxes],
+            positions,
+            scores=scores,
+            class_names=class_names,
+            color=text_colors,
+            font_size=font_size,
+            scales=scales,
+            horizontal_alignment=horizontal_alignment)
+
+    if segms is not None:
+        mask_palette = get_palette(mask_color, max_label + 1)
+        colors = [mask_palette[label] for label in labels]
+        colors = np.array(colors, dtype=np.uint8)
+        draw_masks(ax, img, segms, colors, with_edge=True)
+
+        if num_bboxes < segms.shape[0]:
+            segms = segms[num_bboxes:]
+            horizontal_alignment = 'center'
+            areas = []
+            positions = []
+            for mask in segms:
+                _, _, stats, centroids = cv2.connectedComponentsWithStats(
+                    mask.astype(np.uint8), connectivity=8)
+                largest_id = np.argmax(stats[1:, -1]) + 1
+                positions.append(centroids[largest_id])
+                areas.append(stats[largest_id, -1])
+            areas = np.stack(areas, axis=0)
+            scales = _get_adaptive_scales(areas)
+            draw_labels(
+                ax,
+                labels[num_bboxes:],
+                positions,
+                class_names=class_names,
+                color=text_colors,
+                font_size=font_size,
+                scales=scales,
+                horizontal_alignment=horizontal_alignment)
+
+    plt.imshow(img)
+
+    stream, _ = canvas.print_to_buffer()
+    buffer = np.frombuffer(stream, dtype='uint8')
+    img_rgba = buffer.reshape(height, width, 4)
+    rgb, alpha = np.split(img_rgba, [3], axis=2)
+    img = rgb.astype('uint8')
+    img = mmcv.rgb2bgr(img)
 
     if show:
-        imshow(img, win_name, wait_time)
+        # We do not use cv2 for display because in some cases, opencv will
+        # conflict with Qt, it will output a warning: Current thread
+        # is not the object's thread. You can refer to
+        # https://github.com/opencv/opencv-python/issues/46 for details
+        if wait_time == 0:
+            plt.show()
+        else:
+            plt.show(block=False)
+            plt.pause(wait_time)
     if out_file is not None:
-        imwrite(img, out_file)
+        mmcv.imwrite(img, out_file)
+
+    plt.close()
 
     return img

--- a/mmrotate/core/visualization/image.py
+++ b/mmrotate/core/visualization/image.py
@@ -125,7 +125,7 @@ def imshow_det_rbboxes(img,
     assert labels.ndim == 1, \
         f' labels ndim should be 1, but its ndim is {labels.ndim}.'
     assert bboxes is None or bboxes.shape[1] == 5 or bboxes.shape[1] == 6, \
-        f' bboxes.shape[1] should be 4 or 5, but its {bboxes.shape[1]}.'
+        f' bboxes.shape[1] should be 5 or 6, but its {bboxes.shape[1]}.'
     assert bboxes is None or bboxes.shape[0] <= labels.shape[0], \
         'labels.shape[0] should not be less than bboxes.shape[0].'
     assert segms is None or segms.shape[0] == labels.shape[0], \

--- a/mmrotate/core/visualization/image.py
+++ b/mmrotate/core/visualization/image.py
@@ -37,8 +37,8 @@ def _get_adaptive_scales(areas, min_area=800, max_area=30000):
     return scales
 
 
-def draw_bboxes(ax, bboxes, color='g', alpha=0.8, thickness=2):
-    """Draw bounding boxes on the axes.
+def draw_rbboxes(ax, bboxes, color='g', alpha=0.8, thickness=2):
+    """Draw oriented bounding boxes on the axes.
 
     Args:
         ax (matplotlib.Axes): The input axes.
@@ -170,7 +170,7 @@ def imshow_det_rbboxes(img,
         num_bboxes = bboxes.shape[0]
         bbox_palette = palette_val(get_palette(bbox_color, max_label + 1))
         colors = [bbox_palette[label] for label in labels[:num_bboxes]]
-        draw_bboxes(ax, bboxes, colors, alpha=0.8, thickness=thickness)
+        draw_rbboxes(ax, bboxes, colors, alpha=0.8, thickness=thickness)
 
         horizontal_alignment = 'left'
         positions = bboxes[:, :2].astype(np.int32) + thickness

--- a/mmrotate/core/visualization/palette.py
+++ b/mmrotate/core/visualization/palette.py
@@ -1,0 +1,39 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import mmcv
+import numpy as np
+
+
+def get_palette(palette, num_classes):
+    """Get palette from various inputs.
+
+    Args:
+        palette (list[tuple] | str | tuple | :obj:`Color`): palette inputs.
+        num_classes (int): the number of classes.
+
+    Returns:
+        list[tuple[int]]: A list of color tuples.
+    """
+    assert isinstance(num_classes, int)
+
+    if isinstance(palette, list):
+        dataset_palette = palette
+    elif isinstance(palette, tuple):
+        dataset_palette = [palette] * num_classes
+    elif palette == 'random' or palette is None:
+        state = np.random.get_state()
+        # random color
+        np.random.seed(42)
+        palette = np.random.randint(0, 256, size=(num_classes, 3))
+        np.random.set_state(state)
+        dataset_palette = [tuple(c) for c in palette]
+    elif palette == 'dota':
+        from mmrotate.datasets import DOTADataset
+        dataset_palette = DOTADataset.PALETTE
+    elif mmcv.is_str(palette):
+        dataset_palette = [mmcv.color_val(palette)[::-1]] * num_classes
+    else:
+        raise TypeError(f'Invalid type for palette: {type(palette)}')
+
+    assert len(dataset_palette) >= num_classes, \
+        'The length of palette should not be less than `num_classes`.'
+    return dataset_palette

--- a/mmrotate/core/visualization/palette.py
+++ b/mmrotate/core/visualization/palette.py
@@ -29,6 +29,15 @@ def get_palette(palette, num_classes):
     elif palette == 'dota':
         from mmrotate.datasets import DOTADataset
         dataset_palette = DOTADataset.PALETTE
+    elif palette == 'sar':
+        from mmrotate.datasets import SARDataset
+        dataset_palette = SARDataset.PALETTE
+    elif palette == 'hrsc':
+        from mmrotate.datasets import HRSCDataset
+        dataset_palette = HRSCDataset.PALETTE
+    elif palette == 'hrsc_classwise':
+        from mmrotate.datasets import HRSCDataset
+        dataset_palette = HRSCDataset.CLASSWISE_PALETTE
     elif mmcv.is_str(palette):
         dataset_palette = [mmcv.color_val(palette)[::-1]] * num_classes
     else:

--- a/mmrotate/datasets/dota.py
+++ b/mmrotate/datasets/dota.py
@@ -15,8 +15,7 @@ import torch
 from mmcv.ops import nms_rotated
 from mmdet.datasets.custom import CustomDataset
 
-from mmrotate.core import obb2poly_np, poly2obb_np
-from mmrotate.core.evaluation import eval_rbbox_map
+from mmrotate.core import eval_rbbox_map, obb2poly_np, poly2obb_np
 from .builder import ROTATED_DATASETS
 
 
@@ -34,6 +33,11 @@ class DOTADataset(CustomDataset):
                'small-vehicle', 'large-vehicle', 'ship', 'tennis-court',
                'basketball-court', 'storage-tank', 'soccer-ball-field',
                'roundabout', 'harbor', 'swimming-pool', 'helicopter')
+
+    PALETTE = [(165, 42, 42), (189, 183, 107), (0, 255, 0), (255, 0, 0),
+               (138, 43, 226), (255, 128, 0), (255, 0, 255), (0, 255, 255),
+               (255, 193, 193), (0, 51, 153), (255, 250, 205), (0, 139, 139),
+               (255, 255, 0), (147, 116, 116), (0, 0, 255)]
 
     def __init__(self,
                  ann_file,

--- a/mmrotate/datasets/hrsc.py
+++ b/mmrotate/datasets/hrsc.py
@@ -40,6 +40,19 @@ class HRSCDataset(CustomDataset):
                        '10', '11', '12', '13', '14', '15', '16', '17', '18',
                        '19', '20', '22', '24', '25', '26', '27', '28', '29',
                        '30', '31', '32', '33')
+    PALETTE = [
+        (0, 255, 0),
+    ]
+    CLASSWISE_PALETTE = [(220, 20, 60), (119, 11, 32),
+                         (0, 0, 142), (0, 0, 230), (106, 0, 228), (0, 60, 100),
+                         (0, 80, 100), (0, 0, 70), (0, 0, 192), (250, 170, 30),
+                         (100, 170, 30), (220, 220, 0), (175, 116, 175),
+                         (250, 0, 30), (165, 42, 42), (255, 77, 255),
+                         (0, 226, 252), (182, 182, 255), (0, 82, 0),
+                         (120, 166, 157), (110, 76, 0), (174, 57, 255),
+                         (199, 100, 0), (72, 0, 118), (255, 179, 240),
+                         (0, 125, 92), (209, 0, 151), (188, 208, 182),
+                         (0, 220, 176), (255, 99, 164), (92, 0, 73)]
 
     def __init__(self,
                  ann_file,
@@ -54,6 +67,7 @@ class HRSCDataset(CustomDataset):
         self.classwise = classwise
         self.version = version
         if self.classwise:
+            HRSCDataset.PALETTE = HRSCDataset.CLASSWISE_PALETTE
             HRSCDataset.CLASSES = self.HRSC_CLASSES
             self.catid2label = {
                 ('1' + '0' * 6 + cls_id): i

--- a/mmrotate/datasets/sar.py
+++ b/mmrotate/datasets/sar.py
@@ -7,3 +7,6 @@ from .dota import DOTADataset
 class SARDataset(DOTADataset):
     """SAR ship dataset for detection (Support RSSDD and HRSID)."""
     CLASSES = ('ship', )
+    PALETTE = [
+        (0, 255, 0),
+    ]

--- a/mmrotate/models/detectors/base.py
+++ b/mmrotate/models/detectors/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import mmcv
 import numpy as np
+import torch
 from mmdet.models import BaseDetector
 
 from mmrotate.core import imshow_det_rbboxes
@@ -19,10 +20,11 @@ class RotatedBaseDetector(BaseDetector):
                     img,
                     result,
                     score_thr=0.3,
-                    bbox_color=(226, 43, 138),
-                    text_color='white',
+                    bbox_color=(72, 101, 241),
+                    text_color=(72, 101, 241),
+                    mask_color=None,
                     thickness=2,
-                    font_scale=0.25,
+                    font_size=13,
                     win_name='',
                     show=False,
                     wait_time=0,
@@ -36,12 +38,17 @@ class RotatedBaseDetector(BaseDetector):
                 bbox_result or (bbox_result, segm_result).
             score_thr (float, optional): Minimum score of bboxes to be shown.
                 Default: 0.3.
-            bbox_color (str or tuple or :obj:`Color`): Color of bbox lines.
-            text_color (str or tuple or :obj:`Color`): Color of texts.
-            thickness (int): Thickness of lines.
-            font_scale (float): Font scales of texts.
-            win_name (str): The window name.
-            wait_time (int): Value of waitKey param.
+            bbox_color (str or tuple(int) or :obj:`Color`):Color of bbox lines.
+               The tuple of color should be in BGR order. Default: 'green'
+            text_color (str or tuple(int) or :obj:`Color`):Color of texts.
+               The tuple of color should be in BGR order. Default: 'green'
+            mask_color (None or str or tuple(int) or :obj:`Color`):
+               Color of masks. The tuple of color should be in BGR order.
+               Default: None
+            thickness (int): Thickness of lines. Default: 2
+            font_size (int): Font size of texts. Default: 13
+            win_name (str): The window name. Default: ''
+            wait_time (float): Value of waitKey param.
                 Default: 0.
             show (bool): Whether to show the image.
                 Default: False.
@@ -66,33 +73,29 @@ class RotatedBaseDetector(BaseDetector):
         ]
         labels = np.concatenate(labels)
         # draw segmentation masks
-        if segm_result is not None and len(labels) > 0:
+        segms = None
+        if segm_result is not None and len(labels) > 0:  # non empty
             segms = mmcv.concat_list(segm_result)
-            inds = np.where(bboxes[:, -1] > score_thr)[0]
-            np.random.seed(42)
-            color_masks = [
-                np.random.randint(0, 256, (1, 3), dtype=np.uint8)
-                for _ in range(max(labels) + 1)
-            ]
-            for i in inds:
-                i = int(i)
-                color_mask = color_masks[labels[i]]
-                mask = segms[i]
-                img[mask] = img[mask] * 0.5 + color_mask * 0.5
+            if isinstance(segms[0], torch.Tensor):
+                segms = torch.stack(segms, dim=0).detach().cpu().numpy()
+            else:
+                segms = np.stack(segms, axis=0)
         # if out_file specified, do not show image in window
         if out_file is not None:
             show = False
         # draw bounding boxes
-        imshow_det_rbboxes(
+        img = imshow_det_rbboxes(
             img,
             bboxes,
             labels,
+            segms,
             class_names=self.CLASSES,
             score_thr=score_thr,
             bbox_color=bbox_color,
             text_color=text_color,
+            mask_color=mask_color,
             thickness=thickness,
-            font_scale=font_scale,
+            font_size=font_size,
             win_name=win_name,
             show=show,
             wait_time=wait_time,

--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -5,7 +5,7 @@ import os.path as osp
 import numpy as np
 
 from mmrotate.core import visualization as vis
-from mmrotate.datasets import DOTADataset
+from mmrotate.datasets import DOTADataset, HRSCDataset, SARDataset
 
 
 def test_imshow_det_bboxes():
@@ -65,6 +65,15 @@ def test_palette():
     # test dataset str
     palette = vis.get_palette('dota', len(DOTADataset.CLASSES))
     assert len(palette) == len(DOTADataset.CLASSES)
+
+    palette = vis.get_palette('sar', len(SARDataset.CLASSES))
+    assert len(palette) == len(SARDataset.CLASSES)
+
+    palette = vis.get_palette('hrsc', len(HRSCDataset.HRSC_CLASS))
+    assert len(palette) == len(HRSCDataset.HRSC_CLASS)
+
+    palette = vis.get_palette('hrsc_classwise', len(HRSCDataset.HRSC_CLASSES))
+    assert len(palette) == len(HRSCDataset.HRSC_CLASSES)
 
     # test random
     palette1 = vis.get_palette('random', 3)

--- a/tests/test_utils/test_visualization.py
+++ b/tests/test_utils/test_visualization.py
@@ -5,6 +5,7 @@ import os.path as osp
 import numpy as np
 
 from mmrotate.core import visualization as vis
+from mmrotate.datasets import DOTADataset
 
 
 def test_imshow_det_bboxes():
@@ -40,3 +41,35 @@ def test_imshow_det_bboxes():
         image, bbox, label, out_file=tmp_filename, show=False)
     assert osp.isfile(tmp_filename)
     os.remove(tmp_filename)
+
+
+def test_palette():
+    # test list
+    palette = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+    palette_ = vis.get_palette(palette, 3)
+    for color, color_ in zip(palette, palette_):
+        assert color == color_
+
+    # test tuple
+    palette = vis.get_palette((1, 2, 3), 3)
+    assert len(palette) == 3
+    for color in palette:
+        assert color == (1, 2, 3)
+
+    # test color str
+    palette = vis.get_palette('red', 3)
+    assert len(palette) == 3
+    for color in palette:
+        assert color == (255, 0, 0)
+
+    # test dataset str
+    palette = vis.get_palette('dota', len(DOTADataset.CLASSES))
+    assert len(palette) == len(DOTADataset.CLASSES)
+
+    # test random
+    palette1 = vis.get_palette('random', 3)
+    palette2 = vis.get_palette(None, 3)
+    for color1, color2 in zip(palette1, palette2):
+        assert isinstance(color1, tuple)
+        assert isinstance(color2, tuple)
+        assert color1 == color2


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Follow mmdet https://github.com/open-mmlab/mmdetection/pull/6716
#121 
DOTA palette follow [BboxToolkit](https://github.com/jbwang1997/BboxToolkit/blob/master/tools/vis_configs/dota1_0/colors.txt)

before:
![image](https://user-images.githubusercontent.com/11705038/161708980-59ab40b9-2703-4389-84dc-39e246b248ad.png)
after:
![image](https://user-images.githubusercontent.com/11705038/161708830-5f8f0af6-7eea-43c9-9a43-d7d8310f2040.png)

## Modification
Use matplotlib instead of cv2.
Support visualize boxes of diff classes as diff colors.
Add palette for DOTA dataset
Remove `output` in `image_demo.py`

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
