### PR TITLE
[Fix] bug in eval_rbbox_map when labels_ignore is None

### DIFF
--- a/mmrotate/core/evaluation/eval_map.py
+++ b/mmrotate/core/evaluation/eval_map.py
@@ -118,7 +118,7 @@ def get_cls_results(det_results, annotations, class_id):
             cls_gts_ignore.append(ann['bboxes_ignore'][ignore_inds, :])
 
         else:
-            cls_gts_ignore.append(torch.zeros((0, 6), dtype=torch.float64))
+            cls_gts_ignore.append(torch.zeros((0, 5), dtype=torch.float64))
 
     return cls_dets, cls_gts, cls_gts_ignore
 


### PR DESCRIPTION
## Modification
Resolve #208 


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
