### PR TITLE
[Draft] To align s2anet in AP75.

### DIFF
--- a/mmrotate/models/detectors/s2anet.py
+++ b/mmrotate/models/detectors/s2anet.py
@@ -39,7 +39,6 @@ class S2ANet(RotatedBaseDetector):
 
         if self.align_conv_type == 'AlignConv':
             self.align_conv = AlignConvModule(self.feat_channels,
-                                              self.featmap_strides,
                                               self.align_conv_size)
 
         if train_cfg is not None:
@@ -66,7 +65,7 @@ class S2ANet(RotatedBaseDetector):
         outs = self.fam_head(x)
         rois = self.fam_head.refine_bboxes(*outs)
         # rois: list(indexed by images) of list(indexed by levels)
-        align_feat = self.align_conv(x, rois)
+        align_feat = self.align_conv(x, rois, self.featmap_strides)
         outs = self.odm_head(align_feat)
 
         return outs
@@ -91,7 +90,7 @@ class S2ANet(RotatedBaseDetector):
 
         rois = self.fam_head.refine_bboxes(*outs)
         # rois: list(indexed by images) of list(indexed by levels)
-        align_feat = self.align_conv(x, rois)
+        align_feat = self.align_conv(x, rois, self.featmap_strides)
         outs = self.odm_head(align_feat)
         loss_inputs = outs + (gt_bboxes, gt_labels, img_metas)
         loss_refine = self.odm_head.loss(
@@ -119,7 +118,7 @@ class S2ANet(RotatedBaseDetector):
         outs = self.fam_head(x)
         rois = self.fam_head.refine_bboxes(*outs)
         # rois: list(indexed by images) of list(indexed by levels)
-        align_feat = self.align_conv(x, rois)
+        align_feat = self.align_conv(x, rois, self.featmap_strides)
         outs = self.odm_head(align_feat)
 
         bbox_inputs = outs + (img_meta, self.test_cfg, rescale)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
To align s2anet in AP75.

### angle version: le90

AP50: 0.7308946923442238
AP75: 0.39808647194106567
mAP: 0.4041513439917641


Share AlignConv:
AP50: 0.7303287135570301
AP75: 0.3976110736231026
mAP: 0.40538552660428107


S2ANet in OBBDetection (le90):
AP50: 0.7404564819386658
AP75: 0.4473431159850508
mAP: 0.43091639963964745


### angle version: le135

AP50: 0.7335208471375906
AP75: 0.35363571306826697
mAP: 0.3877248770401872

It looks like whether to share AlignConv is doesn't important. 
We need to check what S2Anet's difference between mmrotate and obbdetection.
