### PR TITLE
[Docs] Configure Myst-parser to parse anchor tag

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -108,7 +108,8 @@ html_theme_options = {
 html_static_path = ['_static']
 html_css_files = ['css/readthedocs.css']
 
-# -- Extension configuration -------------------------------------------------
-# Ignore >>> when copying code
-copybutton_prompt_text = r'>>> |\.\.\. '
-copybutton_prompt_is_regexp = True
+# Enable ::: for my_st
+myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 3
+
+language = 'en'


### PR DESCRIPTION
By default, myst-parser did not parse links to anchor tags in markdown files, making these hyperlinks become raw texts in docs. This PR updates myst's configuration to enable this feature.

related PR https://github.com/open-mmlab/mmocr/pull/1012