### PR TITLE
reppoint bug fix when negative image training

### DIFF
--- a/mmrotate/core/bbox/assigners/max_convex_iou_assigner.py
+++ b/mmrotate/core/bbox/assigners/max_convex_iou_assigner.py
@@ -212,6 +212,8 @@ class MaxConvexIoUAssigner(BaseAssigner):
             overlaps (torch.Tensor): Overlaps between k gt_bboxes and n \
                 bboxes, shape(k, n).
         """
+        if gt_rbboxes.size(0) == 0:
+            return gt_rbboxes.new_zeros((0, points.size(0)))
         overlaps = convex_iou(points, gt_rbboxes)
         overlaps = overlaps.transpose(1, 0)
         return overlaps

--- a/mmrotate/models/dense_heads/rotated_reppoints_head.py
+++ b/mmrotate/models/dense_heads/rotated_reppoints_head.py
@@ -822,6 +822,9 @@ class RotatedRepPointsHead(BaseDenseHead):
         Returns:
             Tensor: Losses of all positive samples in single image.
         """
+        if pos_inds.size(0) == 0:
+            pos_loss = bbox_gt.new_zeros(0)
+            return pos_loss,
         pos_scores = cls_score[pos_inds]
         pos_pts_pred = pts_pred[pos_inds]
         pos_bbox_gt = bbox_gt[pos_inds]


### PR DESCRIPTION
bug fix when negative image training using reppoint head

## Motivation
![image](https://user-images.githubusercontent.com/96048392/177271210-3417860a-762f-4446-a06c-9a18f861386b.png)
error when number of gt bbox is zero


## Modification
1. Added exception handling to `get_pos_loss` function of `RotatedRepPointsHead` class.
2. Added exception handling to `convex_overlaps` function of `MaxConvexIoUAssigner` class.
