### PR TITLE
Fix the paper link in kfiou README

### DIFF
--- a/configs/kfiou/README.md
+++ b/configs/kfiou/README.md
@@ -1,6 +1,6 @@
 # KFIoU
 
-> [The KFIoU Loss for Rotated Object Detection](https://arxiv.org/pdf/2101.11952.pdf)
+> [The KFIoU Loss for Rotated Object Detection](https://arxiv.org/pdf/2201.12558.pdf)
 
 <!-- [ALGORITHM] -->
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the paper link in kfiou README.

## Modification

https://arxiv.org/pdf/2101.11952.pdf is the link of paper, "Rethinking Rotated Object Detection with Gaussian Wasserstein Distance Loss", not "The KFIoU Loss for Rotated Object Detection".

## BC-breaking (Optional)

No.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

- [x] 1. Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] 2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] 3. The documentation has been modified accordingly, like docstring or example tutorials.
