### PR TITLE
[Refactor] Add RotDataPreprocessor

### DIFF
--- a/mmrotate/models/data_preprocessors/__init__.py
+++ b/mmrotate/models/data_preprocessors/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .data_preprocessor import RotDataPreprocessor
+
+__all__ = ['RotDataPreprocessor']

--- a/mmrotate/models/data_preprocessors/data_preprocessor.py
+++ b/mmrotate/models/data_preprocessors/data_preprocessor.py
@@ -1,0 +1,70 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Sequence, Tuple
+
+import torch
+from mmdet.models import DetDataPreprocessor
+
+from mmrotate.registry import MODELS
+
+
+@MODELS.register_module()
+class RotDataPreprocessor(DetDataPreprocessor):
+    """Data pre-processor for rotated object detection tasks.
+
+    Comparing with the :class:`mmdet.DetDataPreprocessor`,
+
+    1. It supports convert bbox from 'qbb' to 'rbb'.
+
+    It provides the data pre-processing as follows
+
+    - Collate and move data to the target device.
+    - Pad inputs to the maximum size of current batch with defined
+      ``pad_value``. The padding size can be divisible by a defined
+      ``pad_size_divisor``
+    - Stack inputs to batch_inputs.
+    - Convert inputs from bgr to rgb if the shape of input is (3, H, W).
+    - Normalize image with defined std and mean.
+    - Do batch augmentations during training.
+    - Convert bbox from 'qbb' to 'rbb'.
+
+
+    Args:
+        angle_version (str, Optional): Angle definition of 'rbb'. Can
+        only be 'oc', 'le90', or 'le135'. Defaults to None, which means
+        don't convert bbox from 'qbb' to 'rbb'.
+
+    """
+
+    def __init__(self,
+                 angle_version: Optional(str) = None,
+                 **kwargs):
+        super().__init__(**kwargs)
+        if angle_version is not None:
+            assert angle_version in ['oc', 'le90', 'le135'], \
+            'Unrecognized version, only "oc", "le90", and "le135" are supported'
+        self.angle_version = angle_version
+
+    def forward(self,
+                data: Sequence[dict],
+                training: bool = False) -> Tuple[torch.Tensor, Optional[list]]:
+        """Perform bbox conversion based on ``DetDataPreprocessor``.
+
+        Args:
+            data (Sequence[dict]): data sampled from dataloader.
+            training (bool): Whether to enable training time augmentation.
+
+        Returns:
+            Tuple[torch.Tensor, Optional[list]]: Data in the same format as the
+            model input.
+        """
+        batch_inputs, batch_data_samples = super().forward(
+            data=data, training=training)
+
+        if self.angle_version is None:
+            return batch_inputs, batch_data_samples
+
+        for data_samples in batch_data_samples:
+            data_samples.gt_instances.bboxes.convert_to('rbox')
+            data_samples.gt_instances.bboxes.regularize_boxes(self.angle_version)
+            
+        return batch_inputs, batch_data_samples

--- a/mmrotate/models/data_preprocessors/data_preprocessor.py
+++ b/mmrotate/models/data_preprocessors/data_preprocessor.py
@@ -32,16 +32,14 @@ class RotDataPreprocessor(DetDataPreprocessor):
         angle_version (str, Optional): Angle definition of 'rbb'. Can
         only be 'oc', 'le90', or 'le135'. Defaults to None, which means
         don't convert bbox from 'qbb' to 'rbb'.
-
     """
 
-    def __init__(self,
-                 angle_version: Optional(str) = None,
-                 **kwargs):
+    def __init__(self, angle_version: Optional(str) = None, **kwargs):
         super().__init__(**kwargs)
         if angle_version is not None:
             assert angle_version in ['oc', 'le90', 'le135'], \
-            'Unrecognized version, only "oc", "le90", and "le135" are supported'
+                'Unrecognized version, only "oc", "le90", and "le135" ' \
+                'are supported'
         self.angle_version = angle_version
 
     def forward(self,
@@ -65,6 +63,7 @@ class RotDataPreprocessor(DetDataPreprocessor):
 
         for data_samples in batch_data_samples:
             data_samples.gt_instances.bboxes.convert_to('rbox')
-            data_samples.gt_instances.bboxes.regularize_boxes(self.angle_version)
-            
+            data_samples.gt_instances.bboxes.regularize_boxes(
+                self.angle_version)
+
         return batch_inputs, batch_data_samples

--- a/mmrotate/models/data_preprocessors/data_preprocessor.py
+++ b/mmrotate/models/data_preprocessors/data_preprocessor.py
@@ -11,10 +11,6 @@ from mmrotate.registry import MODELS
 class RotDataPreprocessor(DetDataPreprocessor):
     """Data pre-processor for rotated object detection tasks.
 
-    Comparing with the :class:`mmdet.DetDataPreprocessor`,
-
-    1. It supports convert bbox from 'qbb' to 'rbb'.
-
     It provides the data pre-processing as follows
 
     - Collate and move data to the target device.
@@ -25,7 +21,10 @@ class RotDataPreprocessor(DetDataPreprocessor):
     - Convert inputs from bgr to rgb if the shape of input is (3, H, W).
     - Normalize image with defined std and mean.
     - Do batch augmentations during training.
-    - Convert bbox from 'qbb' to 'rbb'.
+    - Convert bbox from 'QuadriBoxes' to 'RotatedBoxes'.
+    
+    Comparing with the :class:`mmdet.DetDataPreprocessor`,
+    It supports convert bbox from 'QuadriBoxes' to 'RotatedBoxes'.
 
 
     Args:

--- a/tests/test_models/test_data_preprocessors/test_data_preprocessor.py
+++ b/tests/test_models/test_data_preprocessors/test_data_preprocessor.py
@@ -1,0 +1,29 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from math import sqrt
+from unittest import TestCase
+import numpy as np
+import torch
+
+from mmrotate.models.data_preprocessors import RotDataPreprocessor
+from mmengine.testing import assert_allclose
+from mmdet.testing import demo_mm_inputs
+
+class TestRotDataPreprocessor(TestCase):
+
+    def test_init(self):
+        # test angle_version is error
+        with self.assertRaises(AssertionError):
+            RotDataPreprocessor(angle_version='le60')
+
+    def test_forward(self):
+        packed_inputs = demo_mm_inputs(2, [[3, 128, 128]])
+        packed_inputs[0]['data_sample'].gt_instances.bboxes = torch.Tensor([
+            10, 10 + 2 * sqrt(2), 10 + 2 * sqrt(2), 10, 10, 10 - 2 * sqrt(2),
+            10 - 2 * sqrt(2), 10
+        ]).reshape(1, 1, 8)
+        processor = RotDataPreprocessor(angle_version='le90')
+        inputs, data_samples = processor(packed_inputs)        
+
+        th_rboxes = torch.Tensor([10, 10, 4, 4, np.pi / 4]).reshape(1, 1, 5)
+        assert_allclose(data_samples.gt_instances.bboxes.tensor, th_rboxes)
+ 

--- a/tests/test_models/test_data_preprocessors/test_data_preprocessor.py
+++ b/tests/test_models/test_data_preprocessors/test_data_preprocessor.py
@@ -1,12 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from math import sqrt
 from unittest import TestCase
+
 import numpy as np
 import torch
+from mmdet.testing import demo_mm_inputs
+from mmengine.testing import assert_allclose
 
 from mmrotate.models.data_preprocessors import RotDataPreprocessor
-from mmengine.testing import assert_allclose
-from mmdet.testing import demo_mm_inputs
+
 
 class TestRotDataPreprocessor(TestCase):
 
@@ -22,8 +24,7 @@ class TestRotDataPreprocessor(TestCase):
             10 - 2 * sqrt(2), 10
         ]).reshape(1, 1, 8)
         processor = RotDataPreprocessor(angle_version='le90')
-        inputs, data_samples = processor(packed_inputs)        
+        inputs, data_samples = processor(packed_inputs)
 
         th_rboxes = torch.Tensor([10, 10, 4, 4, np.pi / 4]).reshape(1, 1, 5)
         assert_allclose(data_samples.gt_instances.bboxes.tensor, th_rboxes)
- 


### PR DESCRIPTION
## Motivation

Move box conversion to ``DataPreprocessor``, which can significantly reduce the config that needs to be rewritten when switching the rotated box definition.

Original:
```
### oc
train_pipeline = [
    dict(type='LoadImageFromFile', file_client_args=file_client_args),
    dict(type='LoadPolyAnnotations', with_bbox=True),
    dict(type='RResize', scale=(1024, 1024), keep_ratio=True),
    dict(type='RRandomFlip', prob=0.5),
    dict(type='Polygon2OBB', 'oc'),
    dict(type='mmdet.PackDetInputs')
]
val_pipeline = [
    dict(type='LoadImageFromFile', file_client_args=file_client_args),
    dict(type='RResize', scale=(1024, 1024), keep_ratio=True),
    # avoid bboxes being resized
    dict(type='LoadPolyAnnotations', with_bbox=True),
    dict(type='Polygon2OBB', 'oc'),
    dict(
        type='mmdet.PackDetInputs',
        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
                   'scale_factor'))
]

### le90
train_pipeline = [
    dict(type='LoadImageFromFile', file_client_args=file_client_args),
    dict(type='LoadPolyAnnotations', with_bbox=True),
    dict(type='RResize', scale=(1024, 1024), keep_ratio=True),
    dict(type='RRandomFlip', prob=0.5),
    dict(type='Polygon2OBB', 'oc'),
    dict(type='mmdet.PackDetInputs')
]
val_pipeline = [
    dict(type='LoadImageFromFile', file_client_args=file_client_args),
    dict(type='RResize', scale=(1024, 1024), keep_ratio=True),
    # avoid bboxes being resized
    dict(type='LoadPolyAnnotations', with_bbox=True),
    dict(type='Polygon2OBB', 'oc'),
    dict(
        type='mmdet.PackDetInputs',
        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
                   'scale_factor'))
]
```

to
```
### oc
model.data_preprocessor=dict(ang_version='oc')

### le90
model.data_preprocessor=dict(ang_version='le90')
```
