### PR TITLE
[Fix] confusion_matrix.py arguments not working / crashing the script.

### DIFF
--- a/tools/analysis_tools/confusion_matrix.py
+++ b/tools/analysis_tools/confusion_matrix.py
@@ -123,11 +123,8 @@ def analyze_per_img_dets(confusion_matrix,
     for det_label, det_bboxes in enumerate(result):
         det_bboxes = torch.from_numpy(det_bboxes).float()
         if nms_iou_thr:
-            det_bboxes, _ = nms_rotated(
-                det_bboxes[:, :5],
-                det_bboxes[:, -1],
-                nms_iou_thr,
-                score_threshold=score_thr)
+            det_bboxes, _ = nms_rotated(det_bboxes[:, :5], det_bboxes[:, -1],
+                                        nms_iou_thr)
         ious = rbbox_overlaps(det_bboxes[:, :5], gt_bboxes)
         for i, det_bbox in enumerate(det_bboxes):
             score = det_bbox[5]
@@ -261,6 +258,7 @@ def main():
         confusion_matrix,
         dataset.CLASSES + ('background', ),
         save_dir=args.save_dir,
+        color_theme=args.color_theme,
         show=args.show)
 
 


### PR DESCRIPTION
1. Removed invalid `score_threshold` arg  in `nms_rotated` call
2. Passed `--color-theme` to `plot_confusion_matrix`

## Motivation

> Please describe the motivation of this PR and the goal you want to achieve through this PR.

This PR aims to fix a non-working `--color-theme` command line argument and to prevent the script from crashing whenever `--nms-iou-thr` is specified.

## Modification

> Please briefly describe what modification is made in this PR.

The non-working `--color-theme` argument is now passed to the `plot_confusion_matrix` call.
The `--nms-iou-thr` is fixed by removing an invalid `score_threshold` argument  in an `nms_rotated` call.

