### PR TITLE
[Fix] browse_dataset.py not working in python3.10

### DIFF
--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 import os
-from collections import Sequence
+import sys
 from pathlib import Path
 
 import mmcv
@@ -9,6 +9,11 @@ from mmcv import Config, DictAction
 from mmdet.datasets.builder import build_dataset
 
 from mmrotate.core.visualization import imshow_det_rbboxes
+
+if sys.version_info < (3, 3):
+    from collections import Sequence
+else:
+    from collections.abc import Sequence
 
 
 def parse_args():


### PR DESCRIPTION
ABCs were moved from collections to collections.abc in 3.3. Since 3.10, ABCs cannot be imported directly from collections.

## Motivation

> Please describe the motivation of this PR and the goal you want to achieve through this PR.

The script does not work with Python 3.10. The reason is that the abstract base classes in the `collections` module were moved to  `collections.abc` in Python 3.3. Until 3.9, importing an abstract base class from `collections` produced a deprecation warning, and in 3.10 it produces an error.

## Modification

> Please briefly describe what modification is made in this PR.

If version < 3.3 import from `collections` else import from `collections.abc`.
