### PR TITLE
[FIX] Import RotatedBoxes from structures not core

### DIFF
--- a/mmrotate/evaluation/metrics/rotated_coco_metric.py
+++ b/mmrotate/evaluation/metrics/rotated_coco_metric.py
@@ -17,8 +17,8 @@ from mmengine.fileio import dump, load
 from pycocotools.cocoeval import COCOeval
 from terminaltables import AsciiTable
 
-from mmrotate.core import RotatedBoxes
 from mmrotate.registry import METRICS
+from mmrotate.structures.bbox import RotatedBoxes
 
 
 def qbox2rbox_list(boxes: list) -> list:


### PR DESCRIPTION
Import RotatedBoxes from mmrotate.structures.bbox, not mmrotate.core.
