### PR TITLE
[Enhance] use iof for RRandomCrop validation

### DIFF
--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -357,7 +357,8 @@ class RRandomCrop(RandomCrop):
                                    dtype=np.float32)
             bboxes = results[key] - bbox_offset
 
-            windows = np.array([width / 2, height / 2, width, height, 0], dtype=np.float32).reshape(-1, 5)
+            windows = np.array([width / 2, height / 2, width, height, 0],
+                               dtype=np.float32).reshape(-1, 5)
 
             valid_inds = box_iou_rotated(
                 torch.tensor(bboxes), torch.tensor(windows),

--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -4,6 +4,8 @@ import copy
 import cv2
 import mmcv
 import numpy as np
+import torch
+from mmcv.ops import box_iou_rotated
 from mmdet.datasets.pipelines.transforms import (Mosaic, RandomCrop,
                                                  RandomFlip, Resize)
 from numpy import random
@@ -290,6 +292,8 @@ class RRandomCrop(RandomCrop):
             in range [crop_size[0], min(w, crop_size[1])]. Default "absolute".
         allow_negative_crop (bool, optional): Whether to allow a crop that does
             not contain any bbox area. Default False.
+        iof_thr (float): The minimal iof between a object and window.
+            Defaults to 0.7.
 
     Note:
         - If the image is smaller than the absolute crop size, return the
@@ -305,8 +309,10 @@ class RRandomCrop(RandomCrop):
                  crop_size,
                  crop_type='absolute',
                  allow_negative_crop=False,
+                 iof_thr=0.7,
                  version='oc'):
         self.version = version
+        self.iof_thr = iof_thr
         super(RRandomCrop, self).__init__(crop_size, crop_type,
                                           allow_negative_crop)
 
@@ -350,10 +356,11 @@ class RRandomCrop(RandomCrop):
             bbox_offset = np.array([offset_w, offset_h, 0, 0, 0],
                                    dtype=np.float32)
             bboxes = results[key] - bbox_offset
+            
+            windows = np.array([width/2, height/2, width, height, 0] * len(bboxes)).reshape(-1, 5)
 
-            valid_inds = (bboxes[:, 0] >=
-                          0) & (bboxes[:, 0] < width) & (bboxes[:, 1] >= 0) & (
-                              bboxes[:, 1] < height)
+            valid_inds = box_iou_rotated(torch.tensor(bboxes), torch.tensor(windows), mode='iof').numpy() > self.iof_thr
+
             # If the crop does not contain any gt-bbox area and
             # allow_negative_crop is False, skip this image.
             if (key == 'gt_bboxes' and not valid_inds.any()

--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -357,12 +357,11 @@ class RRandomCrop(RandomCrop):
                                    dtype=np.float32)
             bboxes = results[key] - bbox_offset
 
-            windows = np.array([width / 2, height / 2, width, height, 0] *
-                               len(bboxes)).reshape(-1, 5)
+            windows = np.array([width / 2, height / 2, width, height, 0], dtype=np.float32).reshape(-1, 5)
 
             valid_inds = box_iou_rotated(
                 torch.tensor(bboxes), torch.tensor(windows),
-                mode='iof').numpy() > self.iof_thr
+                mode='iof').numpy().squeeze() > self.iof_thr
 
             # If the crop does not contain any gt-bbox area and
             # allow_negative_crop is False, skip this image.

--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -356,10 +356,13 @@ class RRandomCrop(RandomCrop):
             bbox_offset = np.array([offset_w, offset_h, 0, 0, 0],
                                    dtype=np.float32)
             bboxes = results[key] - bbox_offset
-            
-            windows = np.array([width/2, height/2, width, height, 0] * len(bboxes)).reshape(-1, 5)
 
-            valid_inds = box_iou_rotated(torch.tensor(bboxes), torch.tensor(windows), mode='iof').numpy() > self.iof_thr
+            windows = np.array([width / 2, height / 2, width, height, 0] *
+                               len(bboxes)).reshape(-1, 5)
+
+            valid_inds = box_iou_rotated(
+                torch.tensor(bboxes), torch.tensor(windows),
+                mode='iof').numpy() > self.iof_thr
 
             # If the crop does not contain any gt-bbox area and
             # allow_negative_crop is False, skip this image.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Previously, valid_rbboxes are determined with their center points.
Following https://github.com/open-mmlab/mmrotate/blob/bc1ced4cafdc8d62305958512b0195d822ff6c7f/tools/data/dota/split/img_split.py#L79, replace it with more appropriate criteria: IoF(Intersection over foreground)

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
