### PR TITLE
[Fix] Deprecating old type alias due to new version of numpy

### DIFF
--- a/mmrotate/evaluation/functional/mean_ap.py
+++ b/mmrotate/evaluation/functional/mean_ap.py
@@ -37,8 +37,8 @@ def tpfp_default(det_bboxes,
     # an indicator of ignored gts
     det_bboxes = np.array(det_bboxes)
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 

--- a/mmrotate/testing/_utils.py
+++ b/mmrotate/testing/_utils.py
@@ -71,7 +71,7 @@ def _rand_masks(rng, num_boxes, bboxes, img_w, img_h):
     for i, bbox in enumerate(bboxes):
         bbox = bbox.astype(np.int32)
         mask = (rng.rand(1, bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                0.3).astype(np.int)
+                0.3).astype(np.int32)
         masks[i:i + 1, bbox[1]:bbox[3], bbox[0]:bbox[2]] = mask
     return BitmapMasks(masks, height=img_h, width=img_w)
 

--- a/mmrotate/utils/patch/merge_results.py
+++ b/mmrotate/utils/patch/merge_results.py
@@ -77,7 +77,7 @@ def map_masks(masks: np.ndarray, offset: Sequence[int],
             ori_height -= y_end - new_height
             y_end = new_height
 
-        extended_mask = np.zeros((new_height, new_width), dtype=np.bool)
+        extended_mask = np.zeros((new_height, new_width), dtype=bool)
         extended_mask[y_start:y_end,
                       x_start:x_end] = mask[:ori_height, :ori_width]
         mapped.append(extended_mask)

--- a/mmrotate/visualization/local_visualizer.py
+++ b/mmrotate/visualization/local_visualizer.py
@@ -121,7 +121,7 @@ class RotLocalVisualizer(DetLocalVisualizer):
             elif isinstance(masks, (PolygonMasks, BitmapMasks)):
                 masks = masks.to_ndarray()
 
-            masks = masks.astype(np.bool)
+            masks = masks.astype(bool)
 
             max_label = int(max(labels) if len(labels) > 0 else 0)
             mask_color = palette if self.mask_color is None \

--- a/tools/analysis_tools/browse_dataset.py
+++ b/tools/analysis_tools/browse_dataset.py
@@ -2,7 +2,6 @@
 import argparse
 import os.path as osp
 
-import numpy as np
 from mmdet.models.utils import mask2ndarray
 from mmdet.registry import DATASETS, VISUALIZERS
 from mmdet.structures.bbox import BaseBoxes
@@ -71,7 +70,7 @@ def main():
         gt_masks = gt_instances.get('masks', None)
         if gt_masks is not None:
             masks = mask2ndarray(gt_masks)
-            gt_instances.masks = masks.astype(np.bool)
+            gt_instances.masks = masks.astype(bool)
         data_sample.gt_instances = gt_instances
 
         visualizer.add_datasample(


### PR DESCRIPTION
## Motivation

Deprecating old type alias due to new version of numpy.

## Modification

1. Replace the `np.int` with `np.int32`.
2. Replace all `np.bool` with `bool`.
