### PR TITLE
[Fix] Fix using multiprocessing when formatting

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -119,6 +119,12 @@ def main():
 
     cfg = compat_cfg(cfg)
 
+    if args.format_only and cfg.mp_start_method != 'spawn':
+        warnings.warn(
+            '`mp_start_method` in `cfg` is set to `spawn` to use CUDA '
+            'with multiprocessing when formatting output result.')
+        cfg.mp_start_method = 'spawn'
+
     # set multi-process settings
     setup_multi_processes(cfg)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
After introducing `setup_multi_processes` in `tools.test.py`, `dataset.format_results(output, **kwargs)` becomes seriously slow because it silently handles the error when merging results.
The error message is `RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method`, which is not related to GPU OOM.


## Modification

When formatting the result, change `mp_start_method` to `spawn` following https://github.com/pytorch/pytorch/issues/40403#issue-643410598.

