### PR TITLE
limit numpy version

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,3 @@
 # These must be installed before building mmrotate
 cython
-numpy
+numpy<1.24.0


### PR DESCRIPTION
Due to e2cnn compatibility issues, limit numpy<1.24.0