### PR TITLE
[Fix] Fix deprecated `np.bool`

### DIFF
--- a/mmrotate/core/evaluation/eval_map.py
+++ b/mmrotate/core/evaluation/eval_map.py
@@ -33,8 +33,8 @@ def tpfp_default(det_bboxes,
     # an indicator of ignored gts
     det_bboxes = np.array(det_bboxes)
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0], dtype=bool),
+         np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 

--- a/mmrotate/core/evaluation/eval_map.py
+++ b/mmrotate/core/evaluation/eval_map.py
@@ -33,8 +33,8 @@ def tpfp_default(det_bboxes,
     # an indicator of ignored gts
     det_bboxes = np.array(det_bboxes)
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 

--- a/mmrotate/core/patch/merge_results.py
+++ b/mmrotate/core/patch/merge_results.py
@@ -59,7 +59,7 @@ def map_masks(masks, offset, new_shape):
             ori_height -= y_end - new_height
             y_end = new_height
 
-        extended_mask = np.zeros((new_height, new_width), dtype=np.bool)
+        extended_mask = np.zeros((new_height, new_width), dtype=bool)
         extended_mask[y_start:y_end,
                       x_start:x_end] = mask[:ori_height, :ori_width]
         mapped.append(extended_mask)


### PR DESCRIPTION
## Motivation

`np.bool` is deprecated which was alias for python `bool`.

## Modification

Replace `np.bool` with `bool`.



Please check
- https://github.com/open-mmlab/mmdetection/pull/9537
- https://github.com/QUVA-Lab/e2cnn/pull/65