### PR TITLE
[Feature] Support negative patches in PolyRandomRotate

### DIFF
--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -119,6 +119,8 @@ class PolyRandomRotate(object):
             bounds.
         rect_classes (None|list, optional): Specifies classes that needs to
             be rotated by a multiple of 90 degrees.
+        allow_negative (bool, optional): Whether to allow an image that does
+            not contain any bbox area. Default False.
         version  (str, optional): Angle representations. Defaults to 'le90'.
     """
 
@@ -128,6 +130,7 @@ class PolyRandomRotate(object):
                  angles_range=180,
                  auto_bound=False,
                  rect_classes=None,
+                 allow_negative=False,
                  version='le90'):
         self.rotate_ratio = rotate_ratio
         self.auto_bound = auto_bound
@@ -143,6 +146,7 @@ class PolyRandomRotate(object):
         self.angles_range = angles_range
         self.discrete_range = [90, 180, -90, -180]
         self.rect_classes = rect_classes
+        self.allow_negative = allow_negative
         self.version = version
 
     @property
@@ -240,22 +244,24 @@ class PolyRandomRotate(object):
         results['img_shape'] = (bound_h, bound_w, c)
         gt_bboxes = results.get('gt_bboxes', [])
         labels = results.get('gt_labels', [])
-        gt_bboxes = np.concatenate(
-            [gt_bboxes, np.zeros((gt_bboxes.shape[0], 1))], axis=-1)
-        polys = obb2poly_np(gt_bboxes, self.version)[:, :-1].reshape(-1, 2)
-        polys = self.apply_coords(polys).reshape(-1, 8)
-        gt_bboxes = []
-        for pt in polys:
-            pt = np.array(pt, dtype=np.float32)
-            obb = poly2obb_np(pt, self.version) \
-                if poly2obb_np(pt, self.version) is not None\
-                else [0, 0, 0, 0, 0]
-            gt_bboxes.append(obb)
-        gt_bboxes = np.array(gt_bboxes, dtype=np.float32)
-        keep_inds = self.filter_border(gt_bboxes, bound_h, bound_w)
-        gt_bboxes = gt_bboxes[keep_inds, :]
-        labels = labels[keep_inds]
-        if len(gt_bboxes) == 0:
+
+        if len(gt_bboxes):
+            gt_bboxes = np.concatenate(
+                [gt_bboxes, np.zeros((gt_bboxes.shape[0], 1))], axis=-1)
+            polys = obb2poly_np(gt_bboxes, self.version)[:, :-1].reshape(-1, 2)
+            polys = self.apply_coords(polys).reshape(-1, 8)
+            gt_bboxes = []
+            for pt in polys:
+                pt = np.array(pt, dtype=np.float32)
+                obb = poly2obb_np(pt, self.version) \
+                    if poly2obb_np(pt, self.version) is not None\
+                    else [0, 0, 0, 0, 0]
+                gt_bboxes.append(obb)
+            gt_bboxes = np.array(gt_bboxes, dtype=np.float32)
+            keep_inds = self.filter_border(gt_bboxes, bound_h, bound_w)
+            gt_bboxes = gt_bboxes[keep_inds, :]
+            labels = labels[keep_inds]
+        if len(gt_bboxes) == 0 and not self.allow_negative:
             return None
         results['gt_bboxes'] = gt_bboxes
         results['gt_labels'] = labels


### PR DESCRIPTION
## Motivation
Sometimes it is useful to use **negative patches** in the training phase as in https://github.com/open-mmlab/mmdetection/blob/1b7d778da310eccff95bb8e401f5845a03b17ba9/configs/common/lsj_100e_coco_instance.py#L32.
Currently, however, `PolyRandomRotate` does not support negative patches.

## Modification
Add an option to allow negative patches in the `PolyRandomRotate`.
