### PR TITLE
Update ICLR2023 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ A summary can be found in the [Model Zoo](docs/en/model_zoo.md) page.
 - [x] [KLD](configs/kld/README.md) (NeurIPS'2021)
 - [x] [SASM](configs/sasm_reppoints/README.md) (AAAI'2022)
 - [x] [Oriented RepPoints](configs/oriented_reppoints/README.md) (CVPR'2022)
-- [x] [KFIoU](configs/kfiou/README.md) (arXiv)
-- [x] [H2RBox](configs/h2rbox/README.md) (arXiv)
+- [x] [KFIoU](configs/kfiou/README.md) (ICLR'2023)
+- [x] [H2RBox](configs/h2rbox/README.md) (ICLR'2023)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ A summary can be found in the [Model Zoo](docs/en/model_zoo.md) page.
 - [x] [Oriented RepPoints](configs/oriented_reppoints/README.md) (CVPR'2022)
 - [x] [KFIoU](configs/kfiou/README.md) (ICLR'2023)
 - [x] [H2RBox](configs/h2rbox/README.md) (ICLR'2023)
+- [x] [RTMDet](configs/rotated_rtmdet/README.md) (arXiv)
 
 </details>
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -144,8 +144,8 @@ https://user-images.githubusercontent.com/10410257/154433305-416d129b-60c8-44c7-
 - [x] [KLD](configs/kld/README.md) (NeurIPS'2021)
 - [x] [SASM](configs/sasm_reppoints/README.md) (AAAI'2022)
 - [x] [Oriented RepPoints](configs/oriented_reppoints/README.md) (CVPR'2022)
-- [x] [KFIoU](configs/kfiou/README.md) (arXiv)
-- [x] [H2RBox](configs/h2rbox/README.md) (arXiv)
+- [x] [KFIoU](configs/kfiou/README.md) (ICLR'2023)
+- [x] [H2RBox](configs/h2rbox/README.md) (ICLR'2023)
 
 </details>
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -146,6 +146,7 @@ https://user-images.githubusercontent.com/10410257/154433305-416d129b-60c8-44c7-
 - [x] [Oriented RepPoints](configs/oriented_reppoints/README.md) (CVPR'2022)
 - [x] [KFIoU](configs/kfiou/README.md) (ICLR'2023)
 - [x] [H2RBox](configs/h2rbox/README.md) (ICLR'2023)
+- [x] [RTMDet](configs/rotated_rtmdet/README.md) (arXiv)
 
 </details>
 

--- a/configs/h2rbox/README.md
+++ b/configs/h2rbox/README.md
@@ -58,7 +58,7 @@ DIOR
   title={H2RBox: Horizontal Box Annotation is All You Need for Oriented Object Detection},
   author={Yang, Xue and Zhang, Gefan and Li, Wentong and Wang, Xuehui and Zhou, Yue and Yan, Junchi},
 	booktitle={International Conference on Learning Representations},
-	year={2022}
+	year={2023}
 }
 
 ```

--- a/configs/h2rbox/README.md
+++ b/configs/h2rbox/README.md
@@ -54,7 +54,7 @@ DIOR
 ## Citation
 
 ```
-@article{yang2022h2rbox,
+@article{yang2023h2rbox,
   title={H2RBox: Horizontal Box Annotation is All You Need for Oriented Object Detection},
   author={Yang, Xue and Zhang, Gefan and Li, Wentong and Wang, Xuehui and Zhou, Yue and Yan, Junchi},
 	booktitle={International Conference on Learning Representations},

--- a/configs/h2rbox/README.md
+++ b/configs/h2rbox/README.md
@@ -57,8 +57,8 @@ DIOR
 @article{yang2022h2rbox,
   title={H2RBox: Horizontal Box Annotation is All You Need for Oriented Object Detection},
   author={Yang, Xue and Zhang, Gefan and Li, Wentong and Wang, Xuehui and Zhou, Yue and Yan, Junchi},
-  journal={arXiv preprint arXiv:2210.06742},
-  year={2022}
+	booktitle={International Conference on Learning Representations},
+	year={2022}
 }
 
 ```

--- a/configs/kfiou/README.md
+++ b/configs/kfiou/README.md
@@ -46,6 +46,6 @@ DOTA1.0
       title={The KFIoU Loss for Rotated Object Detection},
       author={Xue Yang and Yue Zhou and Gefan Zhang and Jirui Yang and Wentao Wang and Junchi Yan and Xiaopeng Zhang and Qi Tian},
 	booktitle={International Conference on Learning Representations},
-	year={2022}
+	year={2023}
 }
 ```

--- a/configs/kfiou/README.md
+++ b/configs/kfiou/README.md
@@ -42,7 +42,7 @@ DOTA1.0
 ## Citation
 
 ```
-@misc{yang2022kfiou,
+@misc{yang2023kfiou,
       title={The KFIoU Loss for Rotated Object Detection},
       author={Xue Yang and Yue Zhou and Gefan Zhang and Jirui Yang and Wentao Wang and Junchi Yan and Xiaopeng Zhang and Qi Tian},
 	booktitle={International Conference on Learning Representations},

--- a/configs/kfiou/README.md
+++ b/configs/kfiou/README.md
@@ -45,9 +45,7 @@ DOTA1.0
 @misc{yang2022kfiou,
       title={The KFIoU Loss for Rotated Object Detection},
       author={Xue Yang and Yue Zhou and Gefan Zhang and Jirui Yang and Wentao Wang and Junchi Yan and Xiaopeng Zhang and Qi Tian},
-      year={2022},
-      eprint={2201.12558},
-      archivePrefix={arXiv},
-      primaryClass={cs.CV}
+	booktitle={International Conference on Learning Representations},
+	year={2022}
 }
 ```


### PR DESCRIPTION
MMRotate has two models accepted by ICLR2023. Congratulations!

- H2RBox: Horizontal Box Annotation is All You Need for Oriented Object Detection
- The KFIoU Loss for Rotated Object Detection

