### PR TITLE
Set `e2cnn` as an optional dependency

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -48,7 +48,7 @@ jobs:
           name: Install Libraries
           command: |
             sudo apt-get update
-            sudo apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx libjpeg-dev zlib1g-dev libtinfo-dev libncurses5 libgeos-dev git
+            sudo apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx libjpeg-dev zlib1g-dev libtinfo-dev libncurses5 libgeos-dev
       - run:
           name: Configure Python & pip
           command: |

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -97,6 +97,7 @@ jobs:
           command: |
             git clone -b main --depth 1 https://github.com/open-mmlab/mmengine.git /home/circleci/mmengine
             git clone -b dev-3.x --depth 1 https://github.com/open-mmlab/mmdetection.git /home/circleci/mmdetection
+            git clone  --depth 1 https://github.com/QUVA-Lab/e2cnn.git /home/circleci/e2cnn
       - run:
           name: Build Docker image
           command: |
@@ -109,6 +110,7 @@ jobs:
             docker exec mmrotate pip install -U openmim
             docker exec mmrotate mim install 'mmcv >= 2.0.0rc2'
             docker exec mmrotate pip install -e /mmdetection
+            docker exec mmrotate pip install -e /e2cnn
             docker exec mmrotate pip install -r requirements/tests.txt
       - run:
           name: Build and install

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -103,6 +103,7 @@ jobs:
           command: |
             docker build .circleci/docker -t mmrotate:gpu --build-arg PYTORCH=<< parameters.torch >> --build-arg CUDA=<< parameters.cuda >> --build-arg CUDNN=<< parameters.cudnn >>
             docker run --gpus all -t -d -v /home/circleci/project:/mmrotate -v /home/circleci/mmengine:/mmengine -v /home/circleci/mmdetection:/mmdetection -w /mmrotate --name mmrotate mmrotate:gpu
+            docker exec mmrotate apt-get install -y git
       - run:
           name: Install mmrotate dependencies
           command: |
@@ -110,7 +111,6 @@ jobs:
             docker exec mmrotate pip install -U openmim
             docker exec mmrotate mim install 'mmcv >= 2.0.0rc2'
             docker exec mmrotate pip install -e /mmdetection
-            docker exec mmrotate pip install -e /e2cnn
             docker exec mmrotate pip install -r requirements/tests.txt
       - run:
           name: Build and install

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -70,7 +70,6 @@ jobs:
       - run:
           name: Build and install
           command: |
-            pip install 'numpy < 1.24.0'
             pip install -e .
       - run:
           name: Run unittests
@@ -114,7 +113,6 @@ jobs:
       - run:
           name: Build and install
           command: |
-            docker exec mmrotate pip install 'numpy < 1.24.0'
             docker exec mmrotate pip install -e .
       - run:
           name: Run unittests

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -48,7 +48,7 @@ jobs:
           name: Install Libraries
           command: |
             sudo apt-get update
-            sudo apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx libjpeg-dev zlib1g-dev libtinfo-dev libncurses5 libgeos-dev
+            sudo apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx libjpeg-dev zlib1g-dev libtinfo-dev libncurses5 libgeos-dev git
       - run:
           name: Configure Python & pip
           command: |

--- a/.github/workflows/merge_stage_test.yml
+++ b/.github/workflows/merge_stage_test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install other dependencies
         run: pip install -r requirements/tests.txt
       - name: Build and install
-        run: rm -rf .eggs && pip install 'numpy < 1.24.0' && pip install -e .
+        run: rm -rf .eggs && pip install -e .
       - name: Run unittests and generate coverage report
         run: |
           coverage run --branch --source mmrotate -m pytest tests/

--- a/configs/redet/README.md
+++ b/configs/redet/README.md
@@ -33,8 +33,14 @@ Notes:
 
 - `MS` means multiple scale image split.
 - `RR` means random rotation.
+- ReDet needs to install [e2cnn](https://github.com/QUVA-Lab/e2cnn) first, which requires `numpy < 1.24.0`.
+
+```shell
+pip install numpy < 1.24.0
+pip install e2cnn
+```
+
 - Please download pretrained weight of ReResNet from [ReDet](https://github.com/csuhan/ReDet), and put it on `work_dirs/pretrain`. BTW, it is normal for `missing keys in source state_dict: xxx.filter ` to appear in the log. Don't worry!
-- Please use distributed training, there are some bugs when using `train.py`.
 
 ## Citation
 

--- a/configs/redet/README.md
+++ b/configs/redet/README.md
@@ -33,11 +33,10 @@ Notes:
 
 - `MS` means multiple scale image split.
 - `RR` means random rotation.
-- ReDet needs to install [e2cnn](https://github.com/QUVA-Lab/e2cnn) first, which requires `numpy < 1.24.0`.
+- ReDet needs to install [e2cnn](https://github.com/QUVA-Lab/e2cnn) first.
 
 ```shell
-pip install numpy < 1.24.0
-pip install e2cnn
+pip install -e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn
 ```
 
 - Please download pretrained weight of ReResNet from [ReDet](https://github.com/csuhan/ReDet), and put it on `work_dirs/pretrain`. BTW, it is normal for `missing keys in source state_dict: xxx.filter ` to appear in the log. Don't worry!

--- a/mmrotate/models/backbones/re_resnet.py
+++ b/mmrotate/models/backbones/re_resnet.py
@@ -13,10 +13,12 @@ from mmrotate.registry import MODELS
 
 try:
     import e2cnn.nn as enn
+    from e2cnn.nn import EquivariantModule
     from ..utils.enn import (build_enn_divide_feature, build_enn_norm_layer,
                              build_enn_trivial_feature, ennAvgPool, ennConv,
                              ennMaxPool, ennReLU, ennTrivialConv)
 except ImportError:
+    enn = None
     build_enn_divide_feature = None
     build_enn_norm_layer = None
     build_enn_trivial_feature = None
@@ -25,9 +27,10 @@ except ImportError:
     ennMaxPool = None
     ennReLU = None
     ennTrivialConv = None
+    EquivariantModule = BaseModule
 
 
-class BasicBlock(enn.EquivariantModule):
+class BasicBlock(EquivariantModule):
     """BasicBlock for ReResNet.
 
     Args:
@@ -150,7 +153,7 @@ class BasicBlock(enn.EquivariantModule):
             return input_shape
 
 
-class Bottleneck(enn.EquivariantModule):
+class Bottleneck(EquivariantModule):
     """Bottleneck block for ReResNet.
 
     Args:
@@ -503,7 +506,7 @@ class ReResNet(BaseModule):
         super().__init__(init_cfg=init_cfg)
 
         try:
-            import e2cnn.nn as enn  # noqa: F401
+            import e2cnn  # noqa: F401
         except ImportError:
             raise ImportError('Please install e2cnn by "pip install e2cnn", '
                               'which requires numpy < 1.24.0')

--- a/mmrotate/models/backbones/re_resnet.py
+++ b/mmrotate/models/backbones/re_resnet.py
@@ -508,9 +508,10 @@ class ReResNet(BaseModule):
         try:
             import e2cnn  # noqa: F401
         except ImportError:
-            raise ImportError('Please install e2cnn by "pip install e2cnn", '
-                              'which requires numpy < 1.24.0')
-
+            raise ImportError(
+                'Please install e2cnn by '
+                '"pip install -e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"'
+            )
         self.in_type = build_enn_trivial_feature(in_channels)
         if depth not in self.arch_settings:
             raise KeyError(f'invalid depth {depth} for resnet')

--- a/mmrotate/models/backbones/re_resnet.py
+++ b/mmrotate/models/backbones/re_resnet.py
@@ -509,9 +509,8 @@ class ReResNet(BaseModule):
             import e2cnn  # noqa: F401
         except ImportError:
             raise ImportError(
-                'Please install e2cnn by '
-                '"pip install -e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"'
-            )
+                'Please install e2cnn by "pip install -e '
+                'git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"')
         self.in_type = build_enn_trivial_feature(in_channels)
         if depth not in self.arch_settings:
             raise KeyError(f'invalid depth {depth} for resnet')

--- a/mmrotate/models/backbones/re_resnet.py
+++ b/mmrotate/models/backbones/re_resnet.py
@@ -2,7 +2,6 @@
 # Modified from csuhan: https://github.com/csuhan/ReDet
 from typing import Optional, Sequence, Tuple
 
-import e2cnn.nn as enn
 import torch.nn as nn
 import torch.utils.checkpoint as cp
 from mmdet.utils import ConfigType, OptConfigType, OptMultiConfig
@@ -14,6 +13,12 @@ from mmrotate.registry import MODELS
 from ..utils import (build_enn_divide_feature, build_enn_norm_layer,
                      build_enn_trivial_feature, ennAvgPool, ennConv,
                      ennMaxPool, ennReLU, ennTrivialConv)
+
+try:
+    import e2cnn.nn as enn
+except ImportError:
+    raise ImportError('Please install e2cnn by "pip install e2cnn", '
+                      'which requires numpy < 1.24.0')
 
 
 class BasicBlock(enn.EquivariantModule):

--- a/mmrotate/models/necks/re_fpn.py
+++ b/mmrotate/models/necks/re_fpn.py
@@ -3,7 +3,6 @@
 import warnings
 from typing import List, Optional, Sequence, Tuple, Union
 
-import e2cnn.nn as enn
 import torch.nn as nn
 from mmdet.utils import MultiConfig, OptConfigType
 from mmengine.model import BaseModule
@@ -12,6 +11,12 @@ from torch import Tensor
 from mmrotate.registry import MODELS
 from ..utils import (build_enn_feature, build_enn_norm_layer, ennConv,
                      ennInterpolate, ennMaxPool, ennReLU)
+
+try:
+    import e2cnn.nn as enn
+except ImportError:
+    raise ImportError('Please install e2cnn by "pip install e2cnn", '
+                      'which requires numpy < 1.24.0')
 
 
 class ConvModule(enn.EquivariantModule):

--- a/mmrotate/models/necks/re_fpn.py
+++ b/mmrotate/models/necks/re_fpn.py
@@ -9,14 +9,18 @@ from mmengine.model import BaseModule
 from torch import Tensor
 
 from mmrotate.registry import MODELS
-from ..utils import (build_enn_feature, build_enn_norm_layer, ennConv,
-                     ennInterpolate, ennMaxPool, ennReLU)
 
 try:
     import e2cnn.nn as enn
+    from ..utils.enn import (build_enn_feature, build_enn_norm_layer, ennConv,
+                             ennInterpolate, ennMaxPool, ennReLU)
 except ImportError:
-    raise ImportError('Please install e2cnn by "pip install e2cnn", '
-                      'which requires numpy < 1.24.0')
+    build_enn_feature = None
+    build_enn_norm_layer = None
+    ennConv = None
+    ennInterpolate = None
+    ennMaxPool = None
+    ennReLU = None
 
 
 class ConvModule(enn.EquivariantModule):
@@ -207,7 +211,11 @@ class ReFPN(BaseModule):
         init_cfg: MultiConfig = dict(
             type='Xavier', layer='Conv2d', distribution='uniform')
     ) -> None:
-
+        try:
+            import e2cnn.nn as enn  # noqa: F401
+        except ImportError:
+            raise ImportError('Please install e2cnn by "pip install e2cnn", '
+                              'which requires numpy < 1.24.0')
         super().__init__(init_cfg=init_cfg)
         assert isinstance(in_channels, list)
         self.in_channels = in_channels

--- a/mmrotate/models/necks/re_fpn.py
+++ b/mmrotate/models/necks/re_fpn.py
@@ -217,9 +217,8 @@ class ReFPN(BaseModule):
             import e2cnn  # noqa: F401
         except ImportError:
             raise ImportError(
-                'Please install e2cnn by '
-                '"pip install -e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"'
-            )
+                'Please install e2cnn by "pip install -e '
+                'git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"')
         super().__init__(init_cfg=init_cfg)
         assert isinstance(in_channels, list)
         self.in_channels = in_channels

--- a/mmrotate/models/necks/re_fpn.py
+++ b/mmrotate/models/necks/re_fpn.py
@@ -11,7 +11,8 @@ from torch import Tensor
 from mmrotate.registry import MODELS
 
 try:
-    import e2cnn.nn as enn
+    import e2cnn.nn as enn  # noqa: F401
+    from e2cnn.nn import EquivariantModule
     from ..utils.enn import (build_enn_feature, build_enn_norm_layer, ennConv,
                              ennInterpolate, ennMaxPool, ennReLU)
 except ImportError:
@@ -21,9 +22,10 @@ except ImportError:
     ennInterpolate = None
     ennMaxPool = None
     ennReLU = None
+    EquivariantModule = BaseModule
 
 
-class ConvModule(enn.EquivariantModule):
+class ConvModule(EquivariantModule):
     """ConvModule.
 
     Args:
@@ -212,7 +214,7 @@ class ReFPN(BaseModule):
             type='Xavier', layer='Conv2d', distribution='uniform')
     ) -> None:
         try:
-            import e2cnn.nn as enn  # noqa: F401
+            import e2cnn  # noqa: F401
         except ImportError:
             raise ImportError('Please install e2cnn by "pip install e2cnn", '
                               'which requires numpy < 1.24.0')

--- a/mmrotate/models/necks/re_fpn.py
+++ b/mmrotate/models/necks/re_fpn.py
@@ -216,8 +216,10 @@ class ReFPN(BaseModule):
         try:
             import e2cnn  # noqa: F401
         except ImportError:
-            raise ImportError('Please install e2cnn by "pip install e2cnn", '
-                              'which requires numpy < 1.24.0')
+            raise ImportError(
+                'Please install e2cnn by '
+                '"pip install -e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"'
+            )
         super().__init__(init_cfg=init_cfg)
         assert isinstance(in_channels, list)
         self.in_channels = in_channels

--- a/mmrotate/models/utils/__init__.py
+++ b/mmrotate/models/utils/__init__.py
@@ -1,16 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .enn import (build_enn_divide_feature, build_enn_feature,
-                  build_enn_norm_layer, build_enn_trivial_feature, ennAvgPool,
-                  ennConv, ennInterpolate, ennMaxPool, ennReLU, ennTrivialConv)
 from .misc import (convex_overlaps, get_num_level_anchors_inside,
                    levels_to_images, points_center_pts)
 from .orconv import ORConv2d
 from .ripool import RotationInvariantPooling
 
 __all__ = [
-    'ORConv2d', 'RotationInvariantPooling', 'ennConv', 'ennReLU', 'ennAvgPool',
-    'ennMaxPool', 'ennInterpolate', 'build_enn_divide_feature',
-    'build_enn_feature', 'build_enn_norm_layer', 'build_enn_trivial_feature',
-    'ennTrivialConv', 'get_num_level_anchors_inside', 'points_center_pts',
-    'levels_to_images', 'convex_overlaps'
+    'ORConv2d', 'RotationInvariantPooling', 'get_num_level_anchors_inside',
+    'points_center_pts', 'levels_to_images', 'convex_overlaps'
 ]

--- a/mmrotate/models/utils/enn.py
+++ b/mmrotate/models/utils/enn.py
@@ -1,5 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import e2cnn.nn as enn
+try:
+    import e2cnn.nn as enn
+except ImportError:
+    raise ImportError('Please install e2cnn by "pip install e2cnn", '
+                      'which requires numpy < 1.24.0')
+
 from e2cnn import gspaces
 
 N = 8

--- a/mmrotate/models/utils/enn.py
+++ b/mmrotate/models/utils/enn.py
@@ -2,9 +2,9 @@
 try:
     import e2cnn.nn as enn
 except ImportError:
-    raise ImportError('Please install e2cnn by "pip install e2cnn", '
-                      'which requires numpy < 1.24.0')
-
+    raise ImportError(
+        'Please install e2cnn by '
+        '"pip install -e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn"')
 from e2cnn import gspaces
 
 N = 8

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,3 @@
 # These must be installed before building mmrotate
 cython
-numpy<1.24.0
+numpy

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,3 @@
-e2cnn
 matplotlib
 numpy
 pycocotools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,15 +2,13 @@ asynctest
 codecov
 coverage
 cython
-e2cnn
+-e git+https://github.com/QUVA-Lab/e2cnn.git#egg=e2cnn
 flake8
 interrogate
 isort==4.3.21
 # Note: used for kwarray.group_items, this may be ported to mmcv in the future.
 kwarray
 matplotlib
-# numpy's version is restricted by e2cnn
-numpy<1.24.0
 parameterized
 pytest
 scikit-learn

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -9,6 +9,7 @@ isort==4.3.21
 # Note: used for kwarray.group_items, this may be ported to mmcv in the future.
 kwarray
 matplotlib
+# numpy's version is restricted by e2cnn
 numpy<1.24.0
 parameterized
 pytest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -9,6 +9,7 @@ isort==4.3.21
 # Note: used for kwarray.group_items, this may be ported to mmcv in the future.
 kwarray
 matplotlib
+numpy<1.24.0
 parameterized
 pytest
 scikit-learn

--- a/tests/test_models/test_backbones/test_re_resnet.py
+++ b/tests/test_models/test_backbones/test_re_resnet.py
@@ -8,7 +8,7 @@ from torch.nn.modules.batchnorm import _BatchNorm
 
 from mmrotate.models.backbones.re_resnet import (BasicBlock, Bottleneck,
                                                  ReResNet, ResLayer)
-from mmrotate.models.utils import build_enn_divide_feature
+from mmrotate.models.utils.enn import build_enn_divide_feature
 
 
 def is_block(modules):

--- a/tests/test_models/test_necks/test_re_fpn.py
+++ b/tests/test_models/test_necks/test_re_fpn.py
@@ -6,7 +6,7 @@ import torch
 from torch.nn.modules.batchnorm import _BatchNorm
 
 from mmrotate.models.necks import ReFPN
-from mmrotate.models.utils import build_enn_divide_feature
+from mmrotate.models.utils.enn import build_enn_divide_feature
 
 
 class TestReFPN(TestCase):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

https://github.com/open-mmlab/mmyolo/pull/513
- Only ReDet use `e2cnn`, so we set it as an optional dependency. 
- Unlimit numpy version.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
