### PR TITLE
Support the instance segmentation task in projects

### DIFF
--- a/projects/rotated_mask_rcnn/README.md
+++ b/projects/rotated_mask_rcnn/README.md
@@ -7,10 +7,10 @@ Author: @xxx.
 This is an implementation of \[XXX\]. -->
 
 This project implements a Mask RCNN for rotated boxes. Benefiting from the BoxType design, we only need to modify the code slightly in mmrotate, and then we can support the instance segmentation task.
+
 <center>
 <img src="https://user-images.githubusercontent.com/10410257/218915978-f09bbf87-360d-4751-b52c-66d765d98035.png">
 </center>
-
 
 ## Usage
 
@@ -37,10 +37,10 @@ python tools/test.py projects/rotated_mask_rcnn/configs/rotated-mask-rcnn_r50_fp
 <!-- List the results as usually done in other model's README. [Example](https://github.com/open-mmlab/mmrotate/blob/1.x/configs/r3det/README.md#results-and-models)
 You should claim whether this is based on the pre-trained weights, which are converted from the official release; or it's a reproduced result obtained from retraining the model in this project. -->
 
-|         Backbone         |  mAP  | Angle | lr schd | Mem (GB) | Inf Time (fps) | Aug | Batch Size |                                      Configs                                       |         Download         |
-| :----------------------: | :---: | :---: | :-----: | :------: | :------------: | :-: | :--------: | :--------------------------------------------------------------------------------: | :----------------------: |
-| ResNet50 (1024,1024,200) | 72.71 |  le90   |   1x    |   -   |      -      |  -  |     2      | [rotated-mask-rcnn_r50_fpn_1x_dota](confsigs/rotated-mask-rcnn_r50_fpn_1x_dota.py) | [model](<>) \| [log](<>) |
-| ResNet50 (1024,1024,200) | 70.74 |  le90   |   1x    |   -   |      -      |  -  |     2      | [rotated-mask-orcnn_r50_fpn_1x_dota](confsigs/rotated-mask-orcnn_r50_fpn_1x_dota.py) | [model](<>) \| [log](<>) |
+|         Backbone         |  mAP  | Angle | lr schd | Mem (GB) | Inf Time (fps) | Aug | Batch Size |                                       Configs                                        |         Download         |
+| :----------------------: | :---: | :---: | :-----: | :------: | :------------: | :-: | :--------: | :----------------------------------------------------------------------------------: | :----------------------: |
+| ResNet50 (1024,1024,200) | 72.71 | le90  |   1x    |    -     |       -        |  -  |     2      |  [rotated-mask-rcnn_r50_fpn_1x_dota](confsigs/rotated-mask-rcnn_r50_fpn_1x_dota.py)  | [model](<>) \| [log](<>) |
+| ResNet50 (1024,1024,200) | 70.74 | le90  |   1x    |    -     |       -        |  -  |     2      | [rotated-mask-orcnn_r50_fpn_1x_dota](confsigs/rotated-mask-orcnn_r50_fpn_1x_dota.py) | [model](<>) \| [log](<>) |
 
 Although the rotated box indicator will drop slightly after adding mask head, it may help improve the instance segmentation task. We hope this project can inspire you and welcome you to explore more uses of mmrotate!
 
@@ -66,21 +66,21 @@ OpenMMLab's maintainer will review the code to ensure the project's quality. Rea
 Note that keeping this section up-to-date is crucial not only for this project's developers but the entire community, since there might be some other contributors joining this project and deciding their starting point from this list. It also helps maintainers accurately estimate time and effort on further code polishing, if needed.
 A project does not necessarily have to be finished in a single PR, but it's essential for the project to at least reach the first milestone in its very first PR. -->
 
-- [ ] Milestone 1: PR-ready, and acceptable to be one of the `projects/`.
+- [x] Milestone 1: PR-ready, and acceptable to be one of the `projects/`.
 
-  - [ ] Finish the code
+  - [x] Finish the code
 
     <!-- The code's design shall follow existing interfaces and convention. For example, each model component should be registered into `mmrotate.registry.MODELS` and configurable via a config file. -->
 
-  - [ ] Basic docstrings & proper citation
+  - [x] Basic docstrings & proper citation
 
     <!-- Each major object should contain a docstring, describing its functionality and arguments. If you have adapted the code from other open-source projects, don't forget to cite the source project in docstring and make sure your behavior is not against its license. Typically, we do not accept any code snippet under GPL license. [A Short Guide to Open Source Licenses](https://medium.com/nationwide-technology/a-short-guide-to-open-source-licenses-cf5b1c329edd) -->
 
-  - [ ] Test-time correctness
+  - [x] Test-time correctness
 
     <!-- If you are reproducing the result from a paper, make sure your model's inference-time performance matches that in the original paper. The weights usually could be obtained by simply renaming the keys in the official pre-trained weights. This test could be skipped though, if you are able to prove the training-time correctness and check the second milestone. -->
 
-  - [ ] A full README
+  - [x] A full README
 
     <!-- As this template does. -->
 

--- a/projects/rotated_mask_rcnn/configs/_base_/dota_mask.py
+++ b/projects/rotated_mask_rcnn/configs/_base_/dota_mask.py
@@ -78,7 +78,8 @@ val_dataloader = dict(
         pipeline=val_pipeline))
 test_dataloader = val_dataloader
 
-val_evaluator = dict(type='RotatedCocoMetric', metric=['bbox', 'segm'], classwise=True)
+val_evaluator = dict(
+    type='RotatedCocoMetric', metric=['bbox', 'segm'], classwise=True)
 test_evaluator = val_evaluator
 
 # inference on test dataset and format the output results

--- a/projects/rotated_mask_rcnn/configs/rotated-mask-orcnn_r50_fpn_1x_dota.py
+++ b/projects/rotated_mask_rcnn/configs/rotated-mask-orcnn_r50_fpn_1x_dota.py
@@ -103,7 +103,8 @@ model = dict(
             conv_out_channels=256,
             num_classes=15,
             loss_mask=dict(
-                type='mmdet.CrossEntropyLoss', use_mask=True, loss_weight=1.0))),
+                type='mmdet.CrossEntropyLoss', use_mask=True,
+                loss_weight=1.0))),
     train_cfg=dict(
         rpn=dict(
             assigner=dict(

--- a/projects/rotated_mask_rcnn/configs/rotated-mask-rcnn_r50_fpn_1x_dota.py
+++ b/projects/rotated_mask_rcnn/configs/rotated-mask-rcnn_r50_fpn_1x_dota.py
@@ -94,7 +94,8 @@ model = dict(
             conv_out_channels=256,
             num_classes=15,
             loss_mask=dict(
-                type='mmdet.CrossEntropyLoss', use_mask=True, loss_weight=1.0))),
+                type='mmdet.CrossEntropyLoss', use_mask=True,
+                loss_weight=1.0))),
     train_cfg=dict(
         rpn=dict(
             assigner=dict(

--- a/projects/rotated_mask_rcnn/module/__init__.py
+++ b/projects/rotated_mask_rcnn/module/__init__.py
@@ -1,4 +1,4 @@
-from .rotated_fcn_mask_head import RotatedFCNMaskHead, ORCNNFCNMaskHead
+from .rotated_fcn_mask_head import ORCNNFCNMaskHead, RotatedFCNMaskHead
 from .standard_roi_head import RStandardRoIHead
 
 __all__ = ['RotatedFCNMaskHead', 'RStandardRoIHead', 'ORCNNFCNMaskHead']

--- a/projects/rotated_mask_rcnn/module/mask_target.py
+++ b/projects/rotated_mask_rcnn/module/mask_target.py
@@ -2,7 +2,7 @@
 import numpy as np
 import torch
 from torch.nn.modules.utils import _pair
-from mmcv.ops.roi_align_rotated import roi_align_rotated
+
 from mmrotate.structures import rbox2hbox
 
 

--- a/projects/rotated_mask_rcnn/module/rotated_fcn_mask_head.py
+++ b/projects/rotated_mask_rcnn/module/rotated_fcn_mask_head.py
@@ -1,21 +1,20 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import List, Tuple
+from typing import List
 
 import numpy as np
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
+from mmdet.models.roi_heads.mask_heads import FCNMaskHead
+from mmdet.models.task_modules.samplers import SamplingResult
+from mmdet.structures.bbox import scale_boxes
+from mmdet.utils import InstanceList
 from mmengine.config import ConfigDict
 from torch import Tensor
 
-from mmdet.models.task_modules.samplers import SamplingResult
-from mmdet.models.roi_heads.mask_heads import FCNMaskHead
-from mmdet.utils import ConfigType, InstanceList, OptConfigType, OptMultiConfig
 from mmrotate.registry import MODELS
-from .mask_target import mask_target
-from mmdet.structures.bbox import scale_boxes
-from mmrotate.structures.bbox import RotatedBoxes
 from mmrotate.structures import rbox2hbox
+from mmrotate.structures.bbox import RotatedBoxes
+from .mask_target import mask_target
 
 BYTES_PER_FLOAT = 4
 # TODO: This memory limit may be too much or too little. It would be better to
@@ -146,12 +145,14 @@ class RotatedFCNMaskHead(FCNMaskHead):
             im_mask[(inds, ) + spatial_inds] = masks_chunk
         return im_mask
 
+
 def _do_paste_mask(masks: Tensor,
-                boxes: Tensor,
-                img_h: int,
-                img_w: int,
-                skip_empty: bool = True) -> tuple:
+                   boxes: Tensor,
+                   img_h: int,
+                   img_w: int,
+                   skip_empty: bool = True) -> tuple:
     """Paste instance masks according to boxes.
+
     This implementation is modified from
     https://github.com/facebookresearch/detectron2/
     Args:
@@ -218,6 +219,7 @@ def _do_paste_mask(masks: Tensor,
     else:
         return img_masks[:, 0], ()
 
+
 @MODELS.register_module()
 class ORCNNFCNMaskHead(RotatedFCNMaskHead):
 
@@ -226,6 +228,7 @@ class ORCNNFCNMaskHead(RotatedFCNMaskHead):
                     rcnn_train_cfg: ConfigDict) -> Tensor:
         """Calculate the ground truth for all samples in a batch according to
         the sampling_results.
+
         Args:
             sampling_results (List[obj:SamplingResult]): Assign results of
                 all images in a batch after sampling.

--- a/projects/rotated_mask_rcnn/module/standard_roi_head.py
+++ b/projects/rotated_mask_rcnn/module/standard_roi_head.py
@@ -1,16 +1,15 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
-import torch
+from mmdet.models.roi_heads import StandardRoIHead
+from mmdet.models.utils import empty_instances
+from mmdet.structures.bbox import bbox2roi
+from mmdet.utils import InstanceList
 from torch import Tensor
 
 from mmrotate.registry import MODELS
-from mmdet.structures.bbox import bbox2roi
-from mmdet.utils import InstanceList
-from mmdet.models.utils import empty_instances
-
-from mmdet.models.roi_heads import StandardRoIHead
 from mmrotate.structures import rbox2hbox
+
 
 @MODELS.register_module()
 class RStandardRoIHead(StandardRoIHead):


### PR DESCRIPTION
This project implements a Mask RCNN for rotated boxes. Benefiting from the BoxType design, we only need to modify the code slightly in mmrotate, and we can support the instance segmentation task. Although the rotated box indicator will drop slightly after adding the mask head, it may help improve the instance segmentation task. 

![P0262__1024__824___1414](https://user-images.githubusercontent.com/10410257/218915978-f09bbf87-360d-4751-b52c-66d765d98035.png)
![P0003__1024__123___0](https://user-images.githubusercontent.com/10410257/218916013-6da4081a-931f-4206-bbe8-f9139ffaacf0.png)

**We hope this project can inspire you and welcome you to explore more uses of mmrotate!**