### PR TITLE
[Fix] Move points_range to the same device with points

### DIFF
--- a/mmrotate/models/task_modules/assigners/convex_assigner.py
+++ b/mmrotate/models/task_modules/assigners/convex_assigner.py
@@ -133,7 +133,7 @@ class ConvexAssigner(BaseAssigner):
         assigned_gt_inds = points.new_zeros((num_points, ), dtype=torch.long)
         # stores the assigned gt dist (to this point) of each point
         assigned_gt_dist = points.new_full((num_points, ), float('inf'))
-        points_range = torch.arange(points.shape[0])
+        points_range = torch.arange(points.shape[0], device=points.device)
 
         for idx in range(num_gts):
             gt_lvl = gt_bboxes_lvl[idx]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix runtime error in https://github.com/open-mmlab/mmrotate/blob/1.x/mmrotate/models/task_modules/assigners/convex_assigner.py#L142

## Modification
mmrotate/models/task_modules/assigners/convex_assigner.py#L136
```diff
class ConvexAssigner(BaseAssigner):
         assigned_gt_inds = points.new_zeros((num_points, ), dtype=torch.long)
         # stores the assigned gt dist (to this point) of each point
         assigned_gt_dist = points.new_full((num_points, ), float('inf'))
-        points_range = torch.arange(points.shape[0])
+        points_range = torch.arange(points.shape[0], device=points.device)
 
         for idx in range(num_gts):
             gt_lvl = gt_bboxes_lvl[idx]
```

## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
