### PR TITLE
[Fix] fix bbox_nms_rotated label device

### DIFF
--- a/mmrotate/core/post_processing/bbox_nms_rotated.py
+++ b/mmrotate/core/post_processing/bbox_nms_rotated.py
@@ -39,7 +39,7 @@ def multiclass_nms_rotated(multi_bboxes,
             multi_scores.size(0), num_classes, 5)
     scores = multi_scores[:, :-1]
 
-    labels = torch.arange(num_classes, dtype=torch.long)
+    labels = torch.arange(num_classes, dtype=torch.long, device=scores.device)
     labels = labels.view(1, -1).expand_as(scores)
     bboxes = bboxes.reshape(-1, 5)
     scores = scores.reshape(-1)


### PR DESCRIPTION
## Motivation

When I validated the installation according to the document [[Verify the inference demo]](https://mmrotate.readthedocs.io/en/latest/install.html#installation:~:text=Step%202.%20Verify,run%20the%20following%20command.), I found that using `demo/image_demo.py` script would result in the following error.

```shell
Traceback (most recent call last):
  File "demo/image_demo.py", line 45, in <module>
    main(args)
  File "demo/image_demo.py", line 32, in main
    result = inference_detector(model, args.img)
  File "/home/cvrsg/anaconda3/envs/openmmlab/lib/python3.8/site-packages/mmdet/apis/inference.py", line 157, in inference_detector
    results = model(return_loss=False, rescale=True, **data)
  File "/home/cvrsg/anaconda3/envs/openmmlab/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/cvrsg/anaconda3/envs/openmmlab/lib/python3.8/site-packages/mmcv/runner/fp16_utils.py", line 119, in new_func
    return old_func(*args, **kwargs)
  File "/home/cvrsg/anaconda3/envs/openmmlab/lib/python3.8/site-packages/mmdet/models/detectors/base.py", line 174, in forward
    return self.forward_test(img, img_metas, **kwargs)
  File "/home/cvrsg/anaconda3/envs/openmmlab/lib/python3.8/site-packages/mmdet/models/detectors/base.py", line 147, in forward_test
    return self.simple_test(imgs[0], img_metas[0], **kwargs)
  File "/home/cvrsg/mmrotate/mmrotate/models/detectors/two_stage.py", line 183, in simple_test
    return self.roi_head.simple_test(
  File "/home/cvrsg/mmrotate/mmrotate/models/roi_heads/rotate_standard_roi_head.py", line 252, in simple_test
    det_bboxes, det_labels = self.simple_test_bboxes(
  File "/home/cvrsg/mmrotate/mmrotate/models/roi_heads/oriented_standard_roi_head.py", line 178, in simple_test_bboxes
    det_bbox, det_label = self.bbox_head.get_bboxes(
  File "/home/cvrsg/anaconda3/envs/openmmlab/lib/python3.8/site-packages/mmcv/runner/fp16_utils.py", line 208, in new_func
    return old_func(*args, **kwargs)
  File "/home/cvrsg/mmrotate/mmrotate/models/roi_heads/bbox_heads/rotated_bbox_head.py", line 418, in get_bboxes
    det_bboxes, det_labels = multiclass_nms_rotated(
  File "/home/cvrsg/mmrotate/mmrotate/core/post_processing/bbox_nms_rotated.py", line 58, in multiclass_nms_rotated
    bboxes, scores, labels = bboxes[inds], scores[inds], labels[inds]
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

## Modification

I set the device for the labels as the device for the scores.
```python
labels = torch.arange(num_classes, dtype=torch.long, device=scores.device)
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
