### PR TITLE
[Fix] box error in h2rbox_head.py

### DIFF
--- a/mmrotate/models/dense_heads/h2rbox_head.py
+++ b/mmrotate/models/dense_heads/h2rbox_head.py
@@ -703,5 +703,5 @@ class H2RBoxHead(RotatedFCOSHead):
                 inds = results.labels == id
                 bboxes[inds, :] = hbox2rbox(rbox2hbox(bboxes[inds, :]))
 
-        results.bboxes = RotatedBoxes(bboxes)
+            results.bboxes = RotatedBoxes(bboxes)
         return results


### PR DESCRIPTION
I tried to run h2rbox with sar ship data set, such as rsdd. But an AssertError raise as:

```
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/mm2/lib/python3.8/site-packages/mmrotate/models/dense_heads/h2rbox_head.py", line 706, in _predict_by_feat_single
    results.bboxes = RotatedBoxes(bboxes)
  File "/mnt/petrelfs/liqingyun/miniconda3/envs/mm2/lib/python3.8/site-packages/mmengine/structures/instance_data.py", line 152, in __setattr__
    assert len(value) == len(self), 'The length of ' \
AssertionError: The length of values 30 is not consistent with the length of this :obj:`InstanceData` 1
```

Here is my config:
```python
"""
NOTE: Steps
1. change dataset-related configs, such as dataloader, evaluator.
2. change size-related item in model and new pipeline configs. (You may require to define a new pipeline for a dataset of different annotation format)
3. change num_classes item in model config.
"""
from mmengine.hub import get_config

_base_ = 'mmrotate::h2rbox/h2rbox-le90_r50_fpn_adamw-1x_dota.py'

dataset_cfg = get_config('mmrotate::_base_/datasets/rsdd.py')
del _base_.train_dataloader
train_dataloader = dataset_cfg.train_dataloader
del _base_.val_dataloader
val_dataloader = dataset_cfg.val_dataloader
del _base_.test_dataloader
test_dataloader = dataset_cfg.test_dataloader
del _base_.val_evaluator
val_evaluator = dataset_cfg.val_evaluator
del _base_.test_evaluator
test_evaluator = dataset_cfg.test_evaluator

img_size = (512, 512)

# optimizer
optim_wrapper = dict(
    optimizer=dict(
        type='AdamW',
        lr=0.00005,
        betas=(0.9, 0.999),
        weight_decay=0.05))

# model
model = dict(
    crop_size=img_size, 
    bbox_head=dict(
        num_classes=1, 
        crop_size=img_size, 
        square_classes=None
    )
)

# load hbox annotations
train_pipeline = [
    dict(type='mmdet.LoadImageFromFile', backend_args=None),
    dict(
        type='mmdet.LoadAnnotations',
        with_bbox=True,
        with_mask=True,
        poly2mask=False),
    # Rotated GTBox, (x,y,w,h,theta)
    dict(type='ConvertMask2BoxType', box_type='rbox'),
    # Horizontal GTBox, (x1,y1,x2,y2)
    dict(type='ConvertBoxType', box_type_mapping=dict(gt_bboxes='hbox')),
    # Horizontal GTBox, (x,y,w,h,theta)
    dict(type='ConvertBoxType', box_type_mapping=dict(gt_bboxes='rbox')),
    dict(type='mmdet.Resize', scale=img_size, keep_ratio=True),
    dict(
        type='mmdet.RandomFlip',
        prob=0.75,
        direction=['horizontal', 'vertical', 'diagonal']),
    dict(type='mmdet.PackDetInputs')
]
train_dataloader.dataset.pipeline = train_pipeline

# runtime
default_hooks = dict(
    checkpoint=dict(type='CheckpointHook', interval=1, max_keep_ckpts=1))
vis_backends = [dict(type='LocalVisBackend'),
                dict(type='TensorboardVisBackend')]
visualizer = dict(
    type='RotLocalVisualizer', vis_backends=vis_backends, name='visualizer')
train_cfg = dict(val_interval=1)


del dataset_cfg
```

There seems to be a lack of indentation, resulting in an assignment bug when square classes are not processed