### PR TITLE
rbbox_overlaps does not accept eps as parameter

### DIFF
--- a/mmrotate/structures/bbox/rotated_boxes.py
+++ b/mmrotate/structures/bbox/rotated_boxes.py
@@ -420,8 +420,7 @@ class RotatedBoxes(BaseBoxes):
             boxes1.tensor,
             boxes2.tensor,
             mode=mode,
-            is_aligned=is_aligned,
-            eps=eps)
+            is_aligned=is_aligned)
 
     @staticmethod
     def from_instance_masks(masks: MaskType) -> 'RotatedBoxes':


### PR DESCRIPTION
## Motivation

The function `mmrotate.structures.bbox.bbox_overlaps.rbbox_overlaps does not accept eps as parameter, so it shouldn't be passed here. I think it should be passed until here because:
- At this point, compatibility with other BaseBoxes is kept;
- The problem affects the RBbox.

## Modification

Delete `eps` parameter to be passed to the `rbbox_overlaps` function.

## BC-breaking (Optional)

It shouldn't.

## Use cases (Optional)

No new features, just bugfixing.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues. -> DONE.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness. -> DONE
3. The documentation has been modified accordingly, like docstring or example tutorials. -> DONE
