### PR TITLE
Fix dota metric score on 1.x dev.

### DIFF
--- a/mmrotate/evaluation/metrics/dota_metric.py
+++ b/mmrotate/evaluation/metrics/dota_metric.py
@@ -197,7 +197,7 @@ class DOTAMetric(BaseMetric):
                 else:
                     raise NotImplementedError
                 for qbox, score in zip(qboxes, scores):
-                    txt_element = [img_id, str(round(float(score), 2))
+                    txt_element = [img_id, str(float(score))
                                    ] + [f'{p:.2f}' for p in qbox]
                     f.writelines(' '.join(txt_element) + '\n')
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As many issue that can't reach the mAP on DOTA datasets.

1. https://github.com/open-mmlab/mmrotate/issues/954#issue-1956589456
2. https://github.com/open-mmlab/mmrotate/issues/955#issue-1961626990

## Modification

I solve this problem by easily fixing the precision of score. But the reason is still confused.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. The documentation has been modified accordingly, like docstring or example tutorials.
