### PR TITLE
1) RRandomCrop Runtime Error Fixed (when only one bounding box exists in the cropped); 2) mAP Print Error Fixed (when #class of model > # class of data); 3) confusion matrix color-theme error fixed!

### DIFF
--- a/mmrotate/core/evaluation/eval_map.py
+++ b/mmrotate/core/evaluation/eval_map.py
@@ -276,12 +276,20 @@ def print_map_summary(mean_ap,
     if scale_ranges is not None:
         assert len(scale_ranges) == num_scales
 
-    num_classes = len(results)
+    # num_classes = len(results)
+    # recalls = np.zeros((num_scales, num_classes), dtype=np.float32)
 
-    recalls = np.zeros((num_scales, num_classes), dtype=np.float32)
+    ####################################################################################################################
+    num_classes = len(dataset) if dataset else len(results)
+    num_results_classes = len(results)
+    min_classes = min(num_classes, num_results_classes)
+    recalls = np.zeros((num_scales, min_classes), dtype=np.float32)
+    ####################################################################################################################
+
     aps = np.zeros((num_scales, num_classes), dtype=np.float32)
     num_gts = np.zeros((num_scales, num_classes), dtype=int)
-    for i, cls_result in enumerate(results):
+    # for i, cls_result in enumerate(results):
+    for i, cls_result in enumerate(results[:min_classes]):
         if cls_result['recall'].size > 0:
             recalls[:, i] = np.array(cls_result['recall'], ndmin=2)[:, -1]
         aps[:, i] = cls_result['ap']
@@ -290,7 +298,8 @@ def print_map_summary(mean_ap,
     if dataset is None:
         label_names = [str(i) for i in range(num_classes)]
     else:
-        label_names = dataset
+        # label_names = dataset
+        label_names = dataset[:min_classes]
 
     if not isinstance(mean_ap, list):
         mean_ap = [mean_ap]
@@ -302,7 +311,8 @@ def print_map_summary(mean_ap,
         table_data = [header]
         for j in range(num_classes):
             row_data = [
-                label_names[j], num_gts[i, j], results[j]['num_dets'],
+                # label_names[j], num_gts[i, j], results[j]['num_dets'],
+                label_names[j], num_gts[i, j], results[j].get('num_dets', 0),
                 f'{recalls[i, j]:.3f}', f'{aps[i, j]:.3f}'
             ]
             table_data.append(row_data)
@@ -310,3 +320,4 @@ def print_map_summary(mean_ap,
         table = AsciiTable(table_data)
         table.inner_footing_row_border = True
         print_log('\n' + table.table, logger=logger)
+

--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -352,7 +352,7 @@ class RRandomCrop(RandomCrop):
             img = img[crop_y1:crop_y2, crop_x1:crop_x2, ...]
             img_shape = img.shape
             results[key] = img
-        results['img_shape'] = img_shape
+        results['img_shape'] = img_shape[:2]
 
         height, width, _ = img_shape
 

--- a/mmrotate/datasets/pipelines/transforms.py
+++ b/mmrotate/datasets/pipelines/transforms.py
@@ -375,6 +375,8 @@ class RRandomCrop(RandomCrop):
             if (key == 'gt_bboxes' and not valid_inds.any()
                     and not allow_negative_crop):
                 return None
+                
+            valid_inds = np.atleast_1d(valid_inds)
             results[key] = bboxes[valid_inds, :]
             # label fields. e.g. gt_labels and gt_labels_ignore
             label_key = self.bbox2label.get(key)


### PR DESCRIPTION
transform pipeline

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

[1]
I tried to use `dict(type='RRandomCrop')` in the list named `train_pipeline` of my configuration *py file, **but it occurs bbox shape mismatch error**, _if only one valid bounding box exists in the cropped image_!

** Error message:
File "/home/yechani9/PycharmProjects/AMOD-ExpKit/mmdetection/mmdet/core/bbox/assigners/max_iou_assigner.py", line 111, in assign
overlaps = self.iou_calculator(gt_bboxes, bboxes)
File "/home/yechani9/PycharmProjects/AMOD-ExpKit/mmdetection/mmdet/core/bbox/iou_calculators/iou2d_calculator.py", line 65, in call
return bbox_overlaps(bboxes1, bboxes2, mode, is_aligned)
File "/home/yechani9/PycharmProjects/AMOD-ExpKit/mmdetection/mmdet/core/bbox/iou_calculators/iou2d_calculator.py", line 198, in bbox_overlaps
**assert bboxes1.shape[:-2] == bboxes2.shape[:-2]
AssertionError**

[2]
I tried to **fix the minor error of `print_map_summary()` when # class of model > # class of data**.
I know " # class of model > # class of data " seems quite nonsense, but sometimes this situation may be intentional (e.g. Pretraining with 4 classes -> Fine-tuning with 10 classes: One simple strategy is to use the model with 10 classes even in pretraining.

[3]
Confusion matrix does not reflect the color-map from `args.color_theme'!

## Modification

For [1],
In RRandomCrop/_crop_data(), `valid_inds` should be 1-dimensional, but sometimes `valid_inds` become 0-dimensional, when only one valid bounding box exists in the cropped image, which occurs **bbox shape mismatch error**! Therefore, I added "valid_inds = np.atleast_1d(valid_inds)" in _crop_data(), in order to avoid such error!

For [2],
I modified some of the code to do Print AP per class, keeping in mind the actual number of classes available.

For [3], I added `color_theme=args.color_theme`!
...
    plot_confusion_matrix(
        confusion_matrix,
        dataset.CLASSES + ('background', ),
        save_dir=args.save_dir,
        show=args.show,
        color_theme=args.color_theme # added
)


## BC-breaking (Optional)

Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

**Luckily, I believe there will be no compatibility issue, as my change is minor!**

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. The documentation has been modified accordingly, like docstring or example tutorials.
